### PR TITLE
Fix KubeControllerManagerDown and KubeSchedulerDown alerts

### DIFF
--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/configmap.yaml
@@ -26,21 +26,3 @@ data:
       kubectl -n kube-system delete pod $pod
       sleep 5
     done
-
-  fix-kube-controller-manager-target-down-alert.sh: |-
-    #!/bin/sh
-
-    echo "Reconfiguring cray-sysmgmt-health-promet-kube-controller-manager servicemonitor"
-    mfile=/tmp/cray-sysmgmt-health-promet-kube-controller-manager.yaml
-    kubectl get servicemonitors.monitoring.coreos.com -n sysmgmt-health cray-sysmgmt-health-promet-kube-controller-manager -o yaml > $mfile
-    sed -i 's/port:.*/port: "10257"/' $mfile
-    kubectl -n sysmgmt-health apply -f $mfile
-
-  fix-kube-scheduler-target-down-alert.sh: |-
-    #!/bin/sh
-
-    echo "Reconfiguring cray-sysmgmt-health-promet-kube-scheduler servicemonitor"
-    mfile=/tmp/cray-sysmgmt-health-promet-kube-scheduler.yaml
-    kubectl get servicemonitors.monitoring.coreos.com -n sysmgmt-health cray-sysmgmt-health-promet-kube-scheduler -o yaml > $mfile
-    sed -i 's/port:.*/port: "10259"/' $mfile
-    kubectl -n sysmgmt-health apply -f $mfile

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
@@ -19,7 +19,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'until kubectl get servicemonitor -n sysmgmt-health cray-sysmgmt-health-promet-kubelet > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-kubelet service monitor to be created"; sleep 5; done; /usr/local/sbin/fix-kube-proxy-target-down-alert.sh; /usr/local/sbin/fix-kubelet-target-down-alert.sh; fix-kube-controller-manager-target-down-alert.sh; fix-kube-scheduler-target-down-alert.sh'
+            - 'until kubectl get servicemonitor -n sysmgmt-health cray-sysmgmt-health-promet-kubelet > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-kubelet service monitor to be created"; sleep 5; done; /usr/local/sbin/fix-kube-proxy-target-down-alert.sh; /usr/local/sbin/fix-kubelet-target-down-alert.sh'
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: patch-service-monitors

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -266,16 +266,23 @@ prometheus-operator:
       resource: true
       resourcePath: "/metrics/resource"
 
-
   kubeControllerManager:
+    service:
+      https: true
+      port: 10257
+      targetPort: 10257
     serviceMonitor:
       https: true
-      insecureSkipVerify: false
+      insecureSkipVerify: true
 
   kubeScheduler:
+    service:
+      https: true
+      port: 10259
+      targetPort: 10259
     serviceMonitor:
       https: true
-      insecureSkipVerify: false
+      insecureSkipVerify: true
 
   kubeEtcd:
     # Configure secure access to the etcd cluster via the key and certs


### PR DESCRIPTION
Also removing some unnecessary work-arounds for target down alerts that are fixed by specifying the secure ports in the values.yaml.