### PR TITLE
Update node-exporter image to v1.2.2 to address collector failed errors

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 8.15.4
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.13.2
+version: 0.13.3

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -300,7 +300,7 @@ prometheus-operator:
 
     image:
       repository: quay.io/prometheus/node-exporter
-      tag: v1.0.0
+      tag: v1.2.2
     resources:
       limits:
         cpu: "6"
@@ -310,8 +310,8 @@ prometheus-operator:
         memory: 1Gi
     extraArgs:
       # Default extra args
-      - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-      - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var\/lib\/kubelet|var\/lib\/containerd.+)($|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
       # Extra goodness
       - --no-collector.netclass
       - --collector.buddyinfo
@@ -325,7 +325,11 @@ prometheus-operator:
       - --collector.systemd
       # tcpstat has potential performance impact
       - --collector.tcpstat
-
+    extraHostVolumeMounts:
+      - mountPath: /var/run/dbus/system_bus_socket
+        name: system-dbus-socket
+        readOnly: true
+        hostPath: /var/run/dbus/system_bus_socket
 
   # Compatibility with dashboards and rules templates
   kube-state-metrics:


### PR DESCRIPTION
Also fix the mount points to ignore that node-exporter sees as an errored devices