### PR TITLE
CASMPET-4912: Fix collecting metrics for / on K8s NCNs

### DIFF
--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -326,10 +326,8 @@ prometheus-operator:
         cpu: "1"
         memory: 1Gi
     extraArgs:
-      # Default extra args
-      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var\/lib\/kubelet|var\/lib\/containerd.+)($|/)
-      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-      # Extra goodness
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/.+)($|/)  # containerd puts container fs's in /run/containerd/
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
       - --no-collector.netclass
       - --collector.buddyinfo
       - --collector.drbd


### PR DESCRIPTION
### Summary and Scope

node-exporter wasn't collecting any metrics for the / filesystem
because on the K8s NCNs its FSTYPE is 'overlay':

```
ncn-m001:~ # findmnt /
TARGET SOURCE        FSTYPE  OPTIONS
/      LiveOS_rootfs overlay rw,relatime,lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork
```

and the filesystem collector is configured to ignore overlay fs's. The
'/' filesystem wasn't an overlay FS originally and overlay fs's are
used for the containers so these were ignored.

This was causing there to be no alert when the `/` filesystem fills up
due to kubelet spewing messages into the logs.

The fix is to not ignore overlay fs's and make sure that the container
fs's are ignored.


IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4912

### Testing

Tested on:

* wasp
* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? N   If not, Why? Based on the change made shouldn't be different than upgrade/downgrade.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

I tested on wasp by editing the cray-sysmgmt-health-prometheus-node-exporter daemonset and checking that the node_filesystem_avail_bytes metrics are now reported for the K8s NCNs.
I tested upgrade / downgrade on vshasta by verifying that the new arguments were applied when the updated helm chart is applied.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
