### PR TITLE
CASMPET-4912: Add back excluded containerd mount point

### DIFF
--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -326,7 +326,7 @@ prometheus-operator:
         cpu: "1"
         memory: 1Gi
     extraArgs:
-      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/.+)($|/)  # containerd puts container fs's in /run/containerd/
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var\/lib\/containerd.+|run/.+)($|/)  # containerd puts container fs's in /run/containerd/
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
       - --no-collector.netclass
       - --collector.buddyinfo


### PR DESCRIPTION
### Summary and Scope

When https://github.com/Cray-HPE/cray-sysmgmt-health/pull/27/files was
made, it removed part of the changes done for
https://github.com/Cray-HPE/cray-sysmgmt-health/commit/68e37942257034ca2c73ea79194ec584d0dddf3b
to "fix the mount points to ignore that node-exporter sees as an
errored devices". This was unintentional and due to developing using
the old charts that are in vshasta. This change adds that back in.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4912

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run? N
Was a fresh Install tested? N   If not, Why? Not necessary due to the nature of the change.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N

WHAT WAS THE EXTENT OF TESTING PERFORMED? manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed to vshasta and made sure node-exporter started up and still worked.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
