### PR TITLE
CASMPET-4967: Bump version to prep for CSM-1.2 release 1

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -2,8 +2,8 @@
 # Copyright 2020, 2021 Hewlett Packard Enterprise Development LP
 #
 apiVersion: v1
-appVersion: 8.15.4
+appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.13.4
+version: 0.14.0


### PR DESCRIPTION
* This is the first release for CSM-1.2
* The latest release for cray-sysmgmt-health in CSM-1.1 uses version 0.13.3
* New features were added.
* Changes are backwards-compatible (assuming the images are available)

This release contains the following changes:

* CASMPET-4912: Fix collecting metrics for / on K8s NCNs
* CASMMON-97: Add critical services Grafana dashboard
* CASM-2455: Aggregate view of kubernetes and microservice health dashboard
* CASMPET-4629: Update node-exporter image to v1.2.2 to address collector failed errors
* Disable etcdHighNumberOfFailedGRPCRequests alerts
* CASMPET-4631: Update prometheus operator to 9.3.1 to bring in rule fixes for KubeAPIErrorBudgetBurn and KubeAPILatencyHigh alerts
* CASM-2454-network dasboard changes
* CASMMON-16 code changes for grafana unbound dashbound
* CASMMON-98: Grafterm dashboard for critical services.