### PR TITLE
CASMPET-4916: Rename alert CephNetworkPacketsDropped to NetworkPacket

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.14.0
+version: 0.14.1

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
@@ -13,3 +13,12 @@ data:
     sed -i 's/node_timex_offset_seconds\s<\s-0.05/node_timex_offset_seconds\ <\ -0.000166/' $mfile
     sed -i 's/300s/1s/' $mfile
     kubectl -n sysmgmt-health apply -f $mfile
+  
+  fix-CephNetworkPacketsDropped-alert.sh: |-
+    #!/bin/sh
+  
+    echo "Renaming cray-sysmgmt-health-ceph-prometheus-alert.rules prometheus CephNetworkPacketsDropped to NetworkPacketsDropped alert rule"
+    mfile=/tmp/cray-sysmgmt-health-NetworkPacketsDropped.yaml
+    kubectl get -n sysmgmt-health prometheusrules cray-sysmgmt-health-ceph-prometheus-alert.rules -o yaml > $mfile
+    sed -i 's/CephNetworkPacketsDropped/NetworkPacketsDropped/' $mfile
+    kubectl -n sysmgmt-health apply -f $mfile

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
@@ -19,7 +19,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'until kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-node-exporter alerts to be created"; sleep 5; done; /usr/local/sbin/fix-NodeClockSkewDetected-alert.sh'
+            - 'until kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-node-exporter alerts to be created"; sleep 5; done; /usr/local/sbin/fix-NodeClockSkewDetected-alert.sh; /usr/local/sbin/fix-CephNetworkPacketsDropped-alert.sh'
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: patch-nodeexporter-alerts


### PR DESCRIPTION

Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

Rename alert CephNetworkPacketsDropped to NetworkPacketsDropped.
The CephNetworkPacketsDropped alert doesn't necessarily indicate there are packets being dropped on an interface on a storage node.  So renaming to NetworkPacketsDropped be more generic.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : Rename alert CephNetworkPacketsDropped to NetworkPacketsDropped	.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves
https://connect.us.cray.com/jira/browse/CASMPET-4916

Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/shandy

alert: NetworkPacketsDropped
expr: irate(node_network_receive_drop_total{device!="lo"}[5m])
  + irate(node_network_transmit_drop_total{device!="lo"}[5m]) > 1
labels:
  oid: 1.3.6.1.4.1.50495.15.1.2.8.2
  severity: warning
  type: ceph_default
annotations:
  description: |
    Node {{ $labels.instance }} experiences packet drop > 1 packet/s on interface {{ $labels.device }}.


Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade