### PR TITLE
CASMPET-4467: Add dynamic monitoring (for Istio)

### DIFF
--- a/kubernetes/cray-sysmgmt-health/README.md
+++ b/kubernetes/cray-sysmgmt-health/README.md
@@ -19,3 +19,42 @@ bash ./fix_datasources.sh
 
 Note: current version of Istio dashboards is from Istio release-1.5.7-patch branch.
 https://github.com/istio/istio/tree/release-1.5.7-patch/manifests/istio-telemetry/grafana/dashboards
+
+
+## Prometheus
+
+### References
+
+* API: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md
+* Documentation: https://github.com/prometheus-operator/prometheus-operator/tree/master/Documentation
+
+### Automatic discovery of Pods and Services
+
+The `kubernetes-pods` PodMonitor looks for Pods with annotations and monitors
+those Pods automatically.
+
+The annotations are:
+
+* `prometheus.io/scrape`: Tells this PodMonitor to include this Pod. Set it to
+  `true` to enable scraping.
+* `prometheus.io/path`: Sets the metrics path to use. Defaults to `/metrics`
+* `prometheus.io/port`: Sets the port to use. If not set then the scrape
+  endpoint won't have a port.
+
+The Istio sidecar injector sets these annotations on the Pods that this monitor
+looks for so that each Pod's istio-proxy sidecar will be scraped.
+
+The annotations could be used by other Pods, too, but it's more likely
+monitoring of other services would be done using annotations on the Service.
+
+The `kubernetes-service-endpoints` ServiceMonitor looks for Services with
+annotations and monitors those Services automatically.
+
+The annotations are:
+
+* `prometheus.io/scrape`: Tells this PodMonitor to include this Pod. Set it to
+  `true` to enable scraping.
+* `prometheus.io/scheme`: Either `http` or `https`.
+* `prometheus.io/path`: Sets the metrics path to use. Defaults to `/metrics`
+* `prometheus.io/port`: Sets the port to use. If not set then the scrape
+  endpoint won't have a port.

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/kubernetes-pods.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/kubernetes-pods.yaml
@@ -1,0 +1,49 @@
+
+# See the chart README.md for some docs on this PodMonitor.
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-kubernetes-pods
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-istio
+    release: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+spec:
+  namespaceSelector:
+    any: true
+  selector: {}
+  podMetricsEndpoints:
+  - relabelings:
+
+    # This relabeling is needed because the operator adds the following
+    # relabeling automatically and can't be told to not add it:
+    #   - source_labels:
+    #     - __meta_kubernetes_pod_container_name
+    #     target_label: container
+    # The automatic relabeling causes there to be a metric for each container
+    # in the pod, but the annotation is for the whole pod and only targets one
+    # container (it's typically the istio-proxy sidecar but could be a different
+    # container).
+    - action: labeldrop
+      regex: container
+
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: "true"
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: (.+)
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: "$1:$2"
+      targetLabel: __address__
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/kubernetes-service-endpoints.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/kubernetes-service-endpoints.yaml
@@ -1,0 +1,40 @@
+
+# See the chart README.md for some docs on this ServiceMonitor.
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-kubernetes-service-endpoints
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-kubernetes-service-endpoints
+    release: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+spec:
+  namespaceSelector:
+    any: true
+  selector: {}
+  endpoints:
+  - relabelings:
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: "true"
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: replace
+      targetLabel: __scheme__
+      regex: (https?)
+    - sourceLabels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: (.+)
+    - sourceLabels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      targetLabel: __address__
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: "$1:$2"
+    - action: labelmap
+      regex: __meta_kubernetes_service_label_(.+)
+    - sourceLabels: [__meta_kubernetes_service_name]
+      action: replace
+      targetLabel: kubernetes_name


### PR DESCRIPTION
This adds a Pod and Service monitor that dynamically finds Pods or
Services to monitor, based on annotations on the Pod or Service. See
the README.

This was copied from the configuration that's used in the Prometheus
instance that's deployed by Istio. It was already doing this dynamic
monitoring to find istio-proxy sidecars and istiod, but it was also
catching several other Services that configure the annotations and we
were getting for free but wouldn't be using anyways.

The Istio Prometheus instance only has the following targets:
* kubernetes-apiservers
* kubernetes-cadvisor
* kubernetes-nodes
* kubernetes-pods
* kubernetes-service-endpoints

The sysmgmt-health Prometheus already has monitors for kubernetes
(apiservers, cadvisor, and nodes), so I didn't change that.

For the kubernetes-pods PodMonitor, I got the configuration from
Istio's Prometheus. It's in the ConfigMap:

```
...
- job_name: 'kubernetes-nodes'
  scheme: https
  tls_config:
    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  kubernetes_sd_configs:
  - role: node
  relabel_configs:
  - action: labelmap
    regex: __meta_kubernetes_node_label_(.+)
  - target_label: __address__
    replacement: kubernetes.default.svc:443
  - source_labels: [__meta_kubernetes_node_name]
    regex: (.+)
    target_label: __metrics_path__
    replacement: /api/v1/nodes/${1}/proxy/metrics
...
```

Then I just converted this to a PodMonitor.

For the kubernetes-service-endpoints ServiceMonitor, that's also in the ConfigMap:

```
- job_name: 'kubernetes-service-endpoints'
  kubernetes_sd_configs:
  - role: endpoints
  relabel_configs:
  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
    action: keep
    regex: true
  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
    action: replace
    target_label: __scheme__
    regex: (https?)
  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
    action: replace
    target_label: __metrics_path__
    regex: (.+)
  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
    action: replace
    target_label: __address__
    regex: ([^:]+)(?::\d+)?;(\d+)
    replacement: $1:$2
  - action: labelmap
    regex: __meta_kubernetes_service_label_(.+)
  - source_labels: [__meta_kubernetes_namespace]
    action: replace
    target_label: kubernetes_namespace
  - source_labels: [__meta_kubernetes_service_name]
    action: replace
    target_label: kubernetes_name
```

Then I just converted this to a ServiceMonitor.

The istio Prometheus doesn't define any alerts.

When this is in place the Prometheus instance deployed by Istio can be
removed. We need to do something with the Istio Prometheus because the
Istio operator will no longer support deploying Prometheus in newer
releases.