### PR TITLE
CASMPET-4467: Add dynamic monitoring (for Istio)

### DIFF
--- a/kubernetes/cray-sysmgmt-health/README.md
+++ b/kubernetes/cray-sysmgmt-health/README.md
@@ -19,3 +19,32 @@ bash ./fix_datasources.sh
 
 Note: current version of Istio dashboards is from Istio release-1.5.7-patch branch.
 https://github.com/istio/istio/tree/release-1.5.7-patch/manifests/istio-telemetry/grafana/dashboards
+
+
+## Prometheus
+
+### References
+
+* API: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md
+* Documentation: https://github.com/prometheus-operator/prometheus-operator/tree/master/Documentation
+
+### kubernetes-pods
+
+The `kubernetes-pods` PodMonitor looks for Pods with annotations and monitors
+those Pods automatically.
+
+The annotations are:
+
+* `prometheus.io/scrape`: Tells this PodMonitor to include this Pod. Set it to
+  `true` to enable scraping.
+* `prometheus.io/path`: Sets the metrics path to use. Defaults to `/metrics`
+* `prometheus.io/port`: Sets the port to use. If not set then the scrape
+  endpoint won't have a port.
+
+The Istio sidecar injector sets these annotations on Pods so that each Pod's
+istio-proxy sidecar will be scraped.
+
+The annotations can be used by other Pods, too, but if the Pod also uses
+sidecar injection that won't work since there's no way to specify monitoring
+multiple containers. Monitoring other containers would likely be done using a
+ServiceMonitor instead.

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/kubernetes-pods.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/kubernetes-pods.yaml
@@ -1,0 +1,49 @@
+
+# See the README.md for docs about using this monitor.
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-kubernetes-pods
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-kubernetes-pods
+    release: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+spec:
+  namespaceSelector:
+    any: true
+  selector: {}
+  podMetricsEndpoints:
+  - relabelings:
+
+    # This relabeling is needed because the operator adds the following
+    # relabeling automatically and can't be told to not add it:
+    #   - source_labels:
+    #     - __meta_kubernetes_pod_container_name
+    #     target_label: container
+    # The automatic relabeling causes there to be a metric for each container
+    # in the pod, but the annotation is for the whole pod and only targets one
+    # container (it's typically the istio-proxy sidecar but could be a different
+    # container).
+    - action: labeldrop
+      regex: container
+
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: "true"
+    - sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      targetLabel: __metrics_path__
+      regex: (.+)
+    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: "$1:$2"
+      targetLabel: __address__
+    - action: labelmap
+      regex: __meta_kubernetes_pod_label_(.+)
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      action: replace
+      targetLabel: pod_name

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -269,7 +269,7 @@ prometheus-operator:
         datasources:
         - name: istio-monitoring
           type: prometheus
-          url: http://prometheus.istio-system:9090
+          url: http://cray-sysmgmt-health-promet-prometheus:9090
           access: proxy
 
 


### PR DESCRIPTION
### Summary and Scope

This adds a Pod monitor that dynamically finds Pods to monitor, based
on annotations on the Pod.

This was copied from the configuration that's used in the Prometheus
instance that's deployed by Istio. It was already doing this dynamic
monitoring to find istio-proxy sidecars and istiod.

The Istio Prometheus instance only has the following targets:
* kubernetes-apiservers
* kubernetes-cadvisor
* kubernetes-nodes
* kubernetes-pods
* kubernetes-service-endpoints

The sysmgmt-health Prometheus already has monitors for kubernetes
(apiservers, cadvisor, and nodes), so I didn't add new monitors for
those.

The kubernetes-service-endpoints created a dynamic monitor for
Services. Because we already have several existing service monitors
and services that have the annotations used by the new dynamic monitor
there wound up being several services that were being scraped twice
with different labels. I investigated some of these and wasn't sure
that this wouldn't cause problems with the alerts and grafana
dashboards so decided to leave it out when it looked like we wouldn't
be missing anything. istio is covered by the kubernetes-pods monitor.

For the kubernetes-pods PodMonitor, I got the configuration from
Istio's Prometheus. It's in the `istio-system/prometheus` ConfigMap:

```
...
- job_name: 'kubernetes-pods'
  kubernetes_sd_configs:
  - role: pod
  relabel_configs:  # If first two labels are present, pod should be scraped  by the istio-secure job.
  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
    action: keep
    regex: true
  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
    action: replace
    target_label: __metrics_path__
    regex: (.+)
  - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
    action: replace
    regex: ([^:]+)(?::\d+)?;(\d+)
    replacement: $1:$2
    target_label: __address__
  - action: labelmap
    regex: __meta_kubernetes_pod_label_(.+)
  - source_labels: [__meta_kubernetes_namespace]
    action: replace
    target_label: namespace
  - source_labels: [__meta_kubernetes_pod_name]
    action: replace
    target_label: pod_name
...
```

Then I just converted this to a PodMonitor.

The istio Prometheus doesn't define any alerts.

When this is in place the Prometheus instance deployed by Istio can be
removed. We need to do something with the Istio Prometheus because the
Istio operator will no longer support deploying Prometheus in newer
releases.

Grafana is reconfigured to point the `istio-monitoring` data source
from the istio prometheus to the sysmgmt prometheus since this now
has the istio metrics and the istio Prometheus is going away.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New Feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4467

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

I deployed this to virtual shasta and made sure that the istio stats were available and looked like the stats in istio-prometheus. I verified that the istio dashboards in grafana still worked.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
