### PR TITLE
CASMTRIAGE-2512:BREAK/FIX: cray-sysmgmt-health-prometheus-snmp-export…

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.15.1
+version: 0.15.2

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -18,7 +18,12 @@ kubectl:
 #   enabled: false
 # nodeExporter:
 #   enabled: true
+
 prometheus-snmp-exporter:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/prom/snmp-exporter
+    tag: v0.20.0
+    pullPolicy: IfNotPresent
 
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
CASMTRIAGE-2512:cray-sysmgmt-health-prometheus-snmp-exporter pod in IPBO in 1.2
snmp_exporter container image will be used when we deploy cray-sysmgmt-health chart.
We have used below non root snmp exporter container
https://github.com/Cray-HPE/container-images/pull/338