### PR TITLE
CASMMON-72, CASMMON-101, CASMMON-100 : Enable SMART metrics, alerts and grafana dashboard for k8s nodes

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.15.4
+version: 0.15.5

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/smartmon/smartmon.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/smartmon/smartmon.json
@@ -1,0 +1,693 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Smartmon Texfile node_exporter Dashboard",
+  "editable": true,
+  "gnetId": 3992,
+  "graphTooltip": 0,
+  "id": 57,
+  "iteration": 1636268520330,
+  "links": [],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "height": "170px",
+      "id": 4,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "smartmon_device_smart_healthy{instance=~\"$instance\"} < 1",
+          "format": "table",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy Disks",
+      "transform": "table",
+      "type": "table-old"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(smartmon_airflow_temperature_cel_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "val {{instance}} {{disk}}",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(smartmon_airflow_temperature_cel_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "raw {{instance}} {{disk}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Disk Temperature",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(smartmon_raw_read_error_rate_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "val {{instance}} {{disk}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(smartmon_spin_retry_count_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "raw {{instance}} {{disk}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Raw Error Read Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(smartmon_total_lbas_written_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "val {{instance}} {{disk}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(smartmon_total_lbas_written_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "raw {{instance}} {{disk}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Raw Error Read Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "smartmon_reallocated_sector_ct_raw_value{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "raw {{instance}} {{disk}}",
+          "refId": "B"
+        },
+        {
+          "expr": "smartmon_reallocated_sector_ct_value{instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "val {{instance}} {{disk}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Reallocated Sectors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "smartmon_current_pending_sector_raw_value{instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "raw {{instance}} {{disk}}",
+          "refId": "B"
+        },
+        {
+          "expr": "smartmon_current_pending_sector_value{instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "val {{instance}} {{disk}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Current Pending Sectors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [
+    "prometheus",
+    "node_exporter",
+    "smartmon"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(smartmon_smartctl_version, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "SMARTMON",
+  "uid": "CGWTF6F7k",
+  "version": 2
+}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/kea-dhcp-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/kea-dhcp-alerts.yaml
@@ -19,7 +19,7 @@ metadata:
 {{- end }}
 spec:
   groups:
-  - name: PostgreSQL-status
+  - name: Kea DHCP status
     rules:
     - alert: DHCPPacketsDeclines
       annotations:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           operator: "Exists"
       terminationGracePeriodSeconds: 5
       containers:
-      - image: image: {{ .Values.smartmetrics.image.repository }}:{{ .Values.smartmetrics.image.tag }}
+      - image: {{ .Values.smartmetrics.image.repository }}:{{ .Values.smartmetrics.image.tag }}
         name: smartmon
         env:
         - name: INTERVAL

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.smartmetrics.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ include "cray-sysmgmt-health.fullname" . }}-node-exporter-smartmon"
+  labels:
+    app.kubernetes.io/name: node-exporter-smartmon
+  namespace: {{ .Release.Namespace }}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter-smartmon
+  template:
+    metadata:
+      name: node-exporter-smartmon
+      labels:
+        app.kubernetes.io/name: node-exporter-smartmon
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      terminationGracePeriodSeconds: 5
+      containers:
+      - image: image: {{ .Values.smartmetrics.image.repository }}:{{ .Values.smartmetrics.image.tag }}
+        name: smartmon
+        env:
+        - name: INTERVAL
+          value: "900"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 25m
+            memory: 50Mi
+          limits:
+            cpu: 80m
+            memory: 75Mi
+        volumeMounts:
+        - mountPath: /usr/local/sbin
+          name: host-dev
+          readOnly: true
+        - mountPath: /var/lib/node_exporter
+          name: host-textfile
+          readOnly: false
+      volumes:
+      - hostPath:
+          path: /dev
+        name: host-dev
+      - hostPath:
+          path: /var/lib/node_exporter
+        name: host-textfile
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
@@ -28,4 +28,124 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: SmartDisabled
+      annotations:
+        message: 'SMART disabled on "{{`{{ $labels.type }}`}}"  "{{`{{ $labels.disk }}`}}" '
+      expr: smartmon_device_smart_available == 1 and smartmon_device_smart_enabled == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: SmartHealth
+      annotations:
+        message: 'SMART unhealthy on "{{`{{ $labels.type }}`}}"  "{{`{{ $labels.disk }}`}}" '
+      expr: smartmon_device_smart_healthy != 1 and smartmon_device_smart_enabled == 1
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartDefects
+      annotations:
+        message: 'SMART defects grow "{{`{{ $labels.type }}`}}"  "{{`{{ $labels.disk }}`}}" '
+      expr: increase(smartmon_grown_defects_count_raw_value[1d]) > 0
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartPowerCycles
+      annotations:
+        message: 'Disk "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" power cycles "{{`{{ printf "%.0f" $value }}`}}"/day '
+      expr: increase(smartmon_power_cycle_count_raw_value[1d]) > 10
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartExpired
+      annotations:
+        message: '"{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" no data for "{{`{{ printf "%.0f" $value }}`}}"min '
+      expr: (time() - smartmon_smartctl_run) / 60 > 30
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartTemp
+      annotations:
+        message: '"{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" temperature: "{{`{{ printf "%.0f" $value }}`}}"C '
+      expr: smartmon_airflow_temperature_cel_raw_value > 40 or smartmon_temperature_celsius_raw_value > 40
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartTemp
+      annotations:
+        message: '"{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" temperature: "{{`{{ printf "%.0f" $value }}`}}"C '
+      expr: smartmon_airflow_temperature_cel_raw_value > 60 or smartmon_temperature_celsius_raw_value > 60
+      for: 5m
+      labels:
+        severity: warning
+    - alert: SmartE2E
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" e2e fails'
+      expr: smartmon_end_to_end_error_value <= smartmon_end_to_end_error_threshold 
+      for: 5m
+      labels:
+        severity: informational
+    - alert: SmartReallocated
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" reallocated sectors '
+      expr: smartmon_reallocated_sector_ct_value <= smartmon_reallocated_sector_ct_threshold
+      for: 1m
+      labels:
+        severity: informational 
+    - alert: SmartProgramFailCountTotal
+      annotations:
+        message: '"{{`{{ $labels.instance }}`}}" of job "{{`{{ $labels.job }}`}}" has less than 10% SMART Program Fail Count Total '
+      expr: smartmon_program_fail_cnt_total_value < smartmon_program_fail_cnt_total_threshold
+      for: 3m
+      labels:
+        severity: critical
+    - alert: SmartECC
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" ecc recovered "{{`{{ printf "%.0f" $value }}`}}"/day '
+      expr: increase(smartmon_hardware_ecc_recovered_raw_value[1d]) > 0
+      for: 1m
+      labels:
+        severity: informational
+    - alert: SmartCRC
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" cable crc errors '
+      expr: smartmon_udma_crc_error_count_raw_value > 0
+      for: 1m
+      labels:
+        severity: informational
+    - alert: SmartPending
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" pending sectors "{{`{{printf "%.0f" $value}}`}}" '
+      expr: smartmon_current_pending_sector_raw_value > 1
+      for: 1m
+      labels:
+        severity: informational
+    - alert: SmartErase
+      annotations:
+        message: 'SMART "{{`{{ $labels.type }}`}}" "{{`{{ $labels.disk }}`}}" erase fail count "{{`{{printf "%.0f" $value}}`}}"/day '
+      expr: increase(smartmon_erase_fail_count_total_raw_value[1d]) > 0
+      for: 1m
+      labels:
+        severity: informational
+    - alert: SMARTReallocatedSectors
+      annotations:
+        message: ' Disk has reallocated sectors '
+      expr: smartmon_reallocated_sector_ct_raw_value > 0
+      for: 1m
+      labels:
+        severity: warning
+    - alert: SMARTMonitorNotRunning
+      annotations:
+        message: ' Periodic SMART monitoring not running (timer/service disabled?) '
+      expr: time() - node_textfile_mtime_seconds{file="smartmon.prom"} > 3600
+      for: 1h
+      labels:
+        severity: info
+    - alert: SmartMonDeviceLifeLeftLow
+      annotations:
+        message: ' "{{`{{ $labels.instance }}`}}" of job "{{`{{ $labels.job }}`}}" is reporting that a physical hard disk has less than 50% expected life left '
+      expr: smartmon_wear_leveling_count_value < smartmon_wear_leveling_count_threshold
+      for: 3m
+      labels:
+        severity: critical
+
 {{- end }}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Copyright 2021 Hewlett Packard Enterprise Development LP
+*/ -}}
+{{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "smartmon-alerts") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "cray-sysmgmt-health.fullname" .) "smartmon-alerts.rules" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+{{- if (index .Values "customRules" "labels") }}
+{{ toYaml (index .Values "customRules" "labels") | indent 4 }}
+{{- end }}
+{{- if (index .Values "customRules" "annotations") }}
+  annotations:
+{{ toYaml (index .Values "customRules" "annotations") | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: SMART status
+    rules:
+    - alert: SmartUnhealthy
+      annotations:
+        message: 'Disk "{{`{{ $labels.disk }}`}}" on host "{{`{{ $labels.instance }}`}}" is unhealthy according to SMART'
+      expr: smartmon_device_smart_healthy != 1    
+      for: 5m
+      labels:
+        severity: critical
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -345,11 +345,18 @@ prometheus-operator:
       - --collector.systemd
       # tcpstat has potential performance impact
       - --collector.tcpstat
+      - --collector.textfile.directory=/var/lib/node_exporter
     extraHostVolumeMounts:
       - mountPath: /var/run/dbus/system_bus_socket
         name: system-dbus-socket
         readOnly: true
         hostPath: /var/run/dbus/system_bus_socket
+      - name: text-file-collector
+        hostPath: /var/lib/node_exporter
+        mountPath: /var/lib/node_exporter
+        readOnly: true
+        mountPropagation: HostToContainer
+
 
   # Compatibility with dashboards and rules templates
   kube-state-metrics:
@@ -368,6 +375,7 @@ customRules:
     postgresql: true
     mdraid: true
     kea-dhcp-alerts: true
+    smartmon-alerts: true
   labels:
     release: cray-sysmgmt-health
   ## Annotations for default rules
@@ -772,3 +780,9 @@ grafterm:
     tag: 1.0.0
   dashboards:
     enabled: true
+
+smartmetrics:
+  enabled: true
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/prom/node-exporter-smartmon
+    tag: v0.1.0


### PR DESCRIPTION
Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

The CephNetworkPacket* alerts are including metrics from K8s nodes
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : Enable smart metrics on k8s nodes using SMARTMON
                      Management nodes should sample SMART data and publish to Prometheus for k8s nodes
					  Generate alerts using smart data for k8s nodes

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves

https://connect.us.cray.com/jira/browse/CASMMON-72
https://connect.us.cray.com/jira/browse/CASMMON-101
https://connect.us.cray.com/jira/browse/CASMMON-100

Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade


![Firesmartunhealth](https://user-images.githubusercontent.com/22464568/141241096-6430dd9f-d8b8-487c-b5d4-fabf5b562e0b.jpg)
![firing groot](https://user-images.githubusercontent.com/22464568/141241113-66de2c30-793f-4ea9-9ced-3cc5ef279e24.jpg)
![groot promth](https://user-images.githubusercontent.com/22464568/141241116-2a0723e7-a01e-4c1a-93e9-5599b27834e2.jpg)
![smart rule](https://user-images.githubusercontent.com/22464568/141241118-779acd20-a825-48f3-a64b-06cb0cac63d2.jpg)
![smartalert](https://user-images.githubusercontent.com/22464568/141241120-d2722a14-fa3f-42ef-baac-fcb1e50a05db.jpg)
![smartmon-grafana](https://user-images.githubusercontent.com/22464568/141241123-54a3fa12-4ad7-460e-9cde-89ce93fc626f.jpg)
![smart-alerts](https://user-images.githubusercontent.com/22464568/141602514-415e5a6e-ac39-4184-85e4-bc919445fde8.jpg)
