### PR TITLE
CASMMON-103:NodeFilesystemAlmostOutOfSpace alerts should be alerting when K8s is going to evict pods

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.15.5
+version: 0.15.6

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
@@ -22,3 +22,15 @@ data:
     kubectl get -n sysmgmt-health prometheusrules cray-sysmgmt-health-ceph-prometheus-alert.rules -o yaml > $mfile
     sed -i 's/CephNetworkPacketsDropped/NetworkPacketsDropped/' $mfile
     kubectl -n sysmgmt-health apply -f $mfile
+
+  fix-NodeFilesystemAlmostOutOfSpace-alert.sh: |-
+    #!/bin/sh
+
+    echo "Reconfiguring cray-sysmgmt-health-promet-node-exporter prometheus NodeFilesystemAlmostOutOfSpace alert rule""
+    mfile=/tmp/cray-sysmgmt-health-NodeFilesystemAlmostOutOfSpace.yaml
+    kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter -o yaml > $mfile
+    sed -i '/alert: NodeFilesystemAlmostOutOfSpace/{N;N;N;N;N;N;s/Filesystem has less than 5% space left/Filesystem has less than 17% space left/}' $mfile
+    sed -i '/alert: NodeFilesystemAlmostOutOfSpace/{N;N;N;N;N;N;N;N;N;s/100 < 5/100 < 17/}' $mfile
+    sed -i '/alert: NodeFilesystemAlmostOutOfSpace/{N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;s/Filesystem has less than 3% space left/Filesystem has less than 15% space left/}' $mfile
+    sed -i '/alert: NodeFilesystemAlmostOutOfSpace/{N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;N;s/100 < 3/100 < 15/}' $mfile
+    kubectl -n sysmgmt-health apply -f $mfile

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
@@ -19,7 +19,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'until kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-node-exporter alerts to be created"; sleep 5; done; /usr/local/sbin/fix-NodeClockSkewDetected-alert.sh; /usr/local/sbin/fix-CephNetworkPacketsDropped-alert.sh'
+            - 'until kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter > /dev/null 2>&1; do echo "Waiting for cray-sysmgmt-health-promet-node-exporter alerts to be created"; sleep 5; done; /usr/local/sbin/fix-NodeClockSkewDetected-alert.sh; /usr/local/sbin/fix-CephNetworkPacketsDropped-alert.sh; /usr/local/sbin/fix-NodeFilesystemAlmostOutOfSpace-alert.sh'
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: patch-nodeexporter-alerts


### PR DESCRIPTION
Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

The CephNetworkPacket* alerts are including metrics from K8s nodes
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : NodeFilesystemAlmostOutOfSpace alerts should be alerting when K8s is going to evict pods

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves

https://connect.us.cray.com/jira/browse/CASMMON-103

Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade
![outofspace](https://user-images.githubusercontent.com/22464568/142195771-d8ac5b42-ee68-47f0-abdf-904ad9e4e227.jpg)
