### PR TITLE
CASMINST-3537:need prometheus alert for istio returning only 503

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.15.7
+version: 0.16.0

--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.15.6
+version: 0.15.7

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Copyright 2021 Hewlett Packard Enterprise Development LP
+*/ -}}
+{{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "istio-alerts") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "cray-sysmgmt-health.fullname" .) "istio-alerts.rules" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+{{- if (index .Values "customRules" "labels") }}
+{{ toYaml (index .Values "customRules" "labels") | indent 4 }}
+{{- end }}
+{{- if (index .Values "customRules" "annotations") }}
+  annotations:
+{{ toYaml (index .Values "customRules" "annotations") | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: Istio-status
+    rules:
+    - alert: IstioHigh5xxErrorRate
+      annotations:
+        message: 'Istio high 5xx error rate (instance "{{`{{ $labels.instance }}`}}")'
+      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+      for: 1m
+      labels:
+        severity: warning
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
@@ -24,7 +24,7 @@ spec:
     - alert: IstioHigh5xxErrorRate
       annotations:
         message: 'Istio high 5xx error rate (instance "{{`{{ $labels.instance }}`}}")'
-      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.*"}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.."}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
       for: 1m
       labels:
         severity: warning

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
@@ -1,5 +1,21 @@
 {{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
+MIT License
+(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 */ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "istio-alerts") }}
 apiVersion: monitoring.coreos.com/v1

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/configmap.yaml
@@ -26,7 +26,7 @@ data:
   fix-NodeFilesystemAlmostOutOfSpace-alert.sh: |-
     #!/bin/sh
 
-    echo "Reconfiguring cray-sysmgmt-health-promet-node-exporter prometheus NodeFilesystemAlmostOutOfSpace alert rule""
+    echo "Reconfiguring cray-sysmgmt-health-promet-node-exporter prometheus NodeFilesystemAlmostOutOfSpace alert rule"
     mfile=/tmp/cray-sysmgmt-health-NodeFilesystemAlmostOutOfSpace.yaml
     kubectl get  -n sysmgmt-health   prometheusrules cray-sysmgmt-health-promet-node-exporter -o yaml > $mfile
     sed -i '/alert: NodeFilesystemAlmostOutOfSpace/{N;N;N;N;N;N;s/Filesystem has less than 5% space left/Filesystem has less than 17% space left/}' $mfile

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -376,6 +376,7 @@ customRules:
     mdraid: true
     kea-dhcp-alerts: true
     smartmon-alerts: true
+    istio-alerts: true
   labels:
     release: cray-sysmgmt-health
   ## Annotations for default rules


### PR DESCRIPTION
Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

The CephNetworkPacket* alerts are including metrics from K8s nodes
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : need prometheus alert for istio returning only 503's

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves

https://connect.us.cray.com/jira/browse/CASMINST-3537

Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade


ncn-w001:~ # curl -s http://$(kubectl get service -n sysmgmt-health cray-sysmgmt-health-promet-prometheus -o jsonpath='{.spec.clusterIP}'):9090/api/v1/rules | jq . |grep -C10 IstioHigh5xxErrorRate
        "interval": 30,
        "evaluationTime": 0.000955274,
        "lastEvaluation": "2021-11-18T13:14:30.268124664Z"
      },
      {
        "name": "Istio-status",
        "file": "/etc/prometheus/rules/prometheus-cray-sysmgmt-health-promet-prometheus-rulefiles-0/sysmgmt-health-cray-sysmgmt-health-istio-alerts.rules.yaml",
        "rules": [
          {
            "state": "inactive",
            "name": "IstioHigh5xxErrorRate",
            "query": "sum(rate(istio_requests_total{reporter=\"destination\",response_code=~\"5.*\"}[5m])) / sum(rate(istio_requests_total{reporter=\"destination\"}[5m])) * 100 > 5",
            "duration": 60,
            "labels": {
              "severity": "warning"
            },
            "annotations": {
              "message": "Istio high 5xx error rate (instance \"{{ $labels.instance }}\")"
            },
            "alerts": [],
            "health": "ok",
