### PR TITLE
CASMMON-57:Alert when /var/lib/containerd full

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.17.0
+version: 0.17.1

--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -6,4 +6,4 @@ appVersion: 9.3.1
 description: An extension of the official prometheus-operator helm chart for monitoring system health.
 name: cray-sysmgmt-health
 home: "cloud/cray-charts"
-version: 0.17.1
+version: 0.18.0

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
@@ -43,3 +43,10 @@ spec:
       for: 1h
       labels:
         severity: critical
+    - alert: ContainerdVolumeFull
+      annotations:
+        message: ' Available space on mountpoint /var/lib/containerd is less than "{{`{{ $value | printf "%.2f" }}`}}" % '
+      expr: node_filesystem_avail_bytes{mountpoint="/var/lib/containerd",job="node-exporter"} / node_filesystem_size_bytes{mountpoint="/var/lib/containerd",job="node-exporter"} < 0.05
+      for: 1h
+      labels:
+        severity: critical

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -351,6 +351,10 @@ prometheus-operator:
         name: system-dbus-socket
         readOnly: true
         hostPath: /var/run/dbus/system_bus_socket
+      - mountPath: /var/lib/containerd
+        name: containerd
+        readOnly: true
+        hostPath: /var/lib/containerd
       - name: text-file-collector
         hostPath: /var/lib/node_exporter
         mountPath: /var/lib/node_exporter


### PR DESCRIPTION
Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

Alert when /var/lib/containerd full

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : https://connect.us.cray.com/jira/browse/CASMMON-57

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves
cray-sysmgmt-health : https://connect.us.cray.com/jira/browse/CASMMON-57

Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade

Test logs:
=======

ncn-w001:~ # curl -s http://10.252.1.10:9100/metrics | grep ^node_fil | grep "/var/lib/containerd"
node_filesystem_avail_bytes{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 5.76970297344e+11
node_filesystem_device_error{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 0
node_filesystem_files{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 3.38453504e+08
node_filesystem_files_free{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 3.35449759e+08
node_filesystem_free_bytes{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 5.76970297344e+11
node_filesystem_readonly{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 0
node_filesystem_size_bytes{device="containerd_overlayfs",fstype="overlay",mountpoint="/var/lib/containerd"} 6.92814323712e+11


ncn-w001:~ # curl -s http://$(kubectl get service -n sysmgmt-health cray-sysmgmt-health-promet-prometheus -o jsonpath='{.spec.clusterIP}'):9090/api/v1/rules | jq . |grep -C10 ContainerdVolumeFull
              "message": " Available space on mountpoint / is less than \"{{ $value | printf \"%.2f\" }}\" % "
            },
            "alerts": [],
            "health": "ok",
            "evaluationTime": 0.001074484,
            "lastEvaluation": "2021-11-23T15:49:20.656566812Z",
            "type": "alerting"
          },
          {
            "state": "inactive",
            "name": "ContainerdVolumeFull",
            "query": "node_filesystem_avail_bytes{job=\"node-exporter\",mountpoint=\"/var/lib/containerd\"} / node_filesystem_size_bytes{job=\"node-exporter\",mountpoint=\"/var/lib/containerd\"} < 0.05",
            "duration": 3600,
            "labels": {
              "severity": "critical"
            },
            "annotations": {
              "message": " Available space on mountpoint /var/lib/containerd is less than \"{{ $value | printf \"%.2f\" }}\" % "
            },
            "alerts": [],
            "health": "ok",
![Contain2](https://user-images.githubusercontent.com/22464568/143066659-f957b252-5e19-465d-8002-f3e1d5e484f2.jpg)
![Container](https://user-images.githubusercontent.com/22464568/143066677-d7119019-1e22-409c-a0c2-5e324bcc3fa8.jpg)
![containerd](https://user-images.githubusercontent.com/22464568/143066687-ce2d17eb-a877-4693-99e8-c1d5ec49e8aa.jpg)

