### PR TITLE
CASMMON-106: Monitoring to catch cases where prometheus logging rate …

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -17,7 +17,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.19.0
+version: 0.20.0
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
@@ -50,3 +50,10 @@ spec:
       for: 1h
       labels:
         severity: critical
+    - alert: DiskWillFillIn4Hours
+      annotations:
+        message: ' Host disk will fill in 4 hours (instance "{{`{{ $labels.instance }}`}}") '
+      expr: predict_linear(node_filesystem_free_bytes{job="node-exporter"}[1h], 4*3600) < 0
+      for: 5m
+      labels:
+        severity: critical

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
@@ -50,10 +50,10 @@ spec:
       for: 1h
       labels:
         severity: critical
-    - alert: DiskWillFillIn4Hours
+    - alert: DiskWillFillIn30Mins
       annotations:
-        message: ' Host disk will fill in 4 hours (instance "{{`{{ $labels.instance }}`}}") '
-      expr: predict_linear(node_filesystem_free_bytes{job="node-exporter"}[1h], 4*3600) < 0
-      for: 5m
+        message: ' Host disk will fill in less than 30 min (instance "{{`{{ $labels.instance }}`}}") '
+      expr: predict_linear(node_filesystem_free_bytes{job="node-exporter"}[5m], 60 * 30) < 0 and on(instance) up{job="node-exporter"}
+      for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
Summary and Scope
EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?

Monitoring to catch cases where prometheus logging rate is unusually high

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

cray-sysmgmt-health : https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-106

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? NO

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml yes incremented for Chart.yaml

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y/N

NOTE FOR RELEASE BRANCHES: YOU NO LONGER NEED TO UPDATE THE .version VERSION ON EVERY PR IF THE PR DOES NOT CHANGE THE CONTENTS OF THE GENERATED CONTAINER IMAGE. IF YOU DO UPDATE .version, YOU ALSO NEED TO UPDATE THE Chart.yaml VERSION (if you have one). IF YOU ARE ONLY UPDATING THE CHART, YOU ONLY NEED TO UPDATE THE Chart.yaml VERSION. THERE MAY STILL BE INSTANCES WHEN THE PR WILL HAVE A GREEN BUILD, BUT WHEN THE PR IS MERGED THE BUILD WILL FAIL DUE TO ADDITIONAL CHECKS. IF THE CONTAINER IMAGES DIFFER, THE BUILD LOGS WILL HAVE IN THEM A LIST OF WHAT CONTENTS HAVE CHANGED IN THE IMAGE, AND A NEW PR WILL NEED TO BE CREATED TO UPDATE BOTH .version AND THE Chart.yaml VERSION.

Issues and Related PRs
LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

Resolves
cray-sysmgmt-health : https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-106

node_filesystem_free_bytes filesystem metric as gauge type from the node exporter, which gives how many free bytes for use.

rate() function only suitable for metrics that are constantly increasing, a.k.a. the metric type that is called a “counter”. It’s not suitable for the “gauge” type.

we have used predict_linear() function instead of rate()
Change will also be needed in

Future work required by CASM-ABC

Merge with

Merge before

Merge after

Testing
LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

Virtual Shasta/groot

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y/N yes
Was an Upgrade tested? Y/N yes
Was a Downgrade tested? Y/N. no
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) UNIT
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL? yes

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? NO
ANY OTHER SPECIAL CONSIDERATIONS? No

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: [N/A]

Additional testing on bare-metal
Compute nodes
V1 system configuration (classic preview)
V1 system configuration with SSDs
V2 system configuration
3rd party software
Broader integration testing
Fresh install
Platform upgrade

Test logs:
steps:
ncn-m001:~ # ssh ncn-m002
Last login: Fri Dec 10 13:12:10 2021 from 10.252.1.12
ncn-m002:~ #  curl -s http://10.252.1.11:9100/metrics | grep 'mountpoint="/"'
node_filesystem_avail_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 5.9400863744e+10
node_filesystem_device_error{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 0
node_filesystem_files{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 7.3176064e+07
node_filesystem_files_free{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 7.1631285e+07
node_filesystem_free_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 5.9400863744e+10
node_filesystem_readonly{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 0
node_filesystem_size_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 1.49791404032e+11
ncn-m002:~ # df -h /
Filesystem      Size  Used Avail Use% Mounted on
LiveOS_rootfs   140G   85G   56G  61% /
ncn-m002:~ # mkdir tmp
ncn-m002:~ # cd tmp
ncn-m002:~/tmp #  fallocate -l 1G test_file1.img
ncn-m002:~/tmp #  df -h /
Filesystem      Size  Used Avail Use% Mounted on
LiveOS_rootfs   140G   86G   55G  62% /
ncn-m002:~/tmp #
ncn-m002:~/tmp # mkdir tmp^C
ncn-m002:~/tmp #  fallocate -l 10G test_file2.img
ncn-m002:~/tmp #  df -h /
Filesystem      Size  Used Avail Use% Mounted on
LiveOS_rootfs   140G   96G   45G  69% /
ncn-m002:~/tmp # df -h /^C
ncn-m002:~/tmp #  fallocate -l 10G test_file3.img
ncn-m002:~/tmp # df -h /
Filesystem      Size  Used Avail Use% Mounted on
LiveOS_rootfs   140G  106G   35G  76% /
ncn-m002:~/tmp #  curl -s http://10.252.1.11:9100/metrics | grep 'mountpoint="/"'
node_filesystem_avail_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 3.6875042816e+10
node_filesystem_device_error{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 0
node_filesystem_files{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 7.3176064e+07
node_filesystem_files_free{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 7.1631271e+07
node_filesystem_free_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 3.6875042816e+10
node_filesystem_readonly{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 0
node_filesystem_size_bytes{device="LiveOS_rootfs",fstype="overlay",mountpoint="/"} 1.49791404032e+11

![diskfill2](https://user-images.githubusercontent.com/22464568/146496592-05ccef15-4690-444d-bf60-7c53760945ca.jpg)

![diskfill](https://user-images.githubusercontent.com/22464568/146413470-68394309-7fe0-4c82-961b-c2fbb4f97686.jpg)
![diskfill1](https://user-images.githubusercontent.com/22464568/146413486-3c807149-0e97-4690-86ac-9afd52abaadd.jpg)

