### PR TITLE
CASMINST-3833 : BREAK/FIX: apiVersion not set chart=cray-sysmgmt-health

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -21,26 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# MIT License
-# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.0
+version: 0.21.1
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/grafana/dashboards/dhcp-kea/keadhcp.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grafana/dashboards/dhcp-kea/keadhcp.yaml
@@ -22,7 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 {{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
 Generated from 'keadhcp' from https://grafana.com/api/dashboards/12688/revisions/2/keadhcp.json
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion (index .Values "prometheus-operator" "kubeTargetVersionOverride") }}

--- a/kubernetes/cray-sysmgmt-health/templates/grafana/dashboards/postgresql/postgresql.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grafana/dashboards/postgresql/postgresql.yaml
@@ -22,8 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 {{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-
 Generated from 'postgres' from https: https://grafana.com/grafana/dashboards/6742/postgres.json
 */ -}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion (index .Values "prometheus-operator" "kubeTargetVersionOverride") }}

--- a/kubernetes/cray-sysmgmt-health/templates/grafterm/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grafterm/configmap.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if .Values.grafterm.dashboards.enabled }}
 ---
 apiVersion: v1

--- a/kubernetes/cray-sysmgmt-health/templates/grafterm/deployment.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grafterm/deployment.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/ -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/node-exporter/post-install.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/node-exporter/post-install.yaml
@@ -21,25 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
+{{/*
 This sets the GOMAXPROCS env var on the prometheus-node-exporter pods. By
 default the Go procs matches the number of CPUs, which doesn't work well when
 you have 64 CPUs.
@@ -51,7 +33,7 @@ https://github.com/prometheus/node_exporter/issues/1880
 This is a Helm hook because the prometheus-operator chart doesn't support
 adding extra environment variables.
 
-*/ -}}
+*/}}
 
 apiVersion: batch/v1
 kind: Job

--- a/kubernetes/cray-sysmgmt-health/templates/node-exporter/rbac.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/node-exporter/rbac.yaml
@@ -22,8 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 {{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-
 This is used by the node-exporter post-install Hook. The Hook needs to do a
 patch operation on the cray-sysmgmt-health-prometheus-node-exporter DeamonSet.
 */ -}}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/ceph/ceph-prometheus-alert.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/ceph/ceph-prometheus-alert.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "ceph") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/ceph/ceph-prometheus.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/ceph/ceph-prometheus.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "ceph") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/kea-dhcp-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/kea-dhcp-alerts.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "kea-dhcp-alerts") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/monitors/cray-dhcp-kea.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/dhcp-kea/monitors/cray-dhcp-kea.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/ -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/mdraid/mdraid-prometheus-alert.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/mdraid/mdraid-prometheus-alert.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "mdraid") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/ -}}
 
 apiVersion: batch/v1
 kind: Job

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- range $key, $val := .Values.servicemonitors }}
 {{- if $val.enabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/ -}}
 
 {{- if .Values.smartmetrics.enabled }}
 apiVersion: apps/v1

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/smartmon-alerts.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "smartmon-alerts") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-MIT License
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-*/ -}}
 
 apiVersion: batch/v1
 kind: Job

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-rm-pals-postgres.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-rm-pals-postgres.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-sls-postgres.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-sls-postgres.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-smd-postgres.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/cray-smd-postgres.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/gitea-vcs-postgres.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/gitea-vcs-postgres.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/keycloak-postgres.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/keycloak-postgres.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/sma-postgres-cluster.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/sma-postgres-cluster.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/spire-postgres-cluster.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/monitors/spire-postgres-cluster.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 kind: ServiceMonitor
 apiVersion: monitoring.coreos.com/v1
 metadata:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/postgres-exporter-service.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/postgres-exporter-service.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if .Values.rmPalsPostgresExporter.enabled }}
 apiVersion: v1
 kind: Service

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/postgres-prometheus-alert.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/postgres/postgres-prometheus-alert.yaml
@@ -21,9 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- /*
-Copyright 2020, 2021 Hewlett Packard Enterprise Development LP
-*/ -}}
 {{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "postgresql") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -21,25 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-#
-# MIT License
-# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-#
 global:
   authGateway: services/services-gateway
   rbac:


### PR DESCRIPTION
## Summary and Scope

Clean up license header changes.
* Remove {{ /* \<LICENSE\> */ }} that existed prior to license-check fix
* Change {{- \/* ... \*\/ -}} to {{\/\* ... \*\/}} in existing code where this resulted in the next line being commented out (e.g. #apiVersion, #kind)
* Keep the license header added by the license-check (which uses # to start the line)
* Update the chart version to prepare to release the cray-sysmgmt-health chart for this change

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-3833](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3833)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:

* Reviewed the output from `helm template .` to look for any remaining template rendering issues.

* Deployed to vshasta
```
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:09:25Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health /workspace/.cache/charts/cray-sysmgmt-health-0.21.1.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=0.21.1 -f /tmp/loftsman-1642702164/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:11:12Z INF Release "cray-sysmgmt-health" does not exist. Installing it now.
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
NAME: cray-sysmgmt-health
LAST DEPLOYED: Thu Jan 20 18:09:27 2022
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 1
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.21.1
2022-01-20T18:11:12Z INF Ship status: success. Recording status, manifest, and log data to configmap loftsman-mine in namespace loftsman command=ship
loftsman log saved to: /workspace/.cache/loftsman.log
```

* Pod are running
```
C02YP47BLVCG:my_workspace kim.jensen$ kubectl get pods -n sysmgmt-health
NAME                                                           READY   STATUS      RESTARTS   AGE
alertmanager-cray-sysmgmt-health-promet-alertmanager-0         2/2     Running     0          3m23s
cray-sysmgmt-health-grafana-5d65f66b79-bbcnr                   2/2     Running     0          3m31s
cray-sysmgmt-health-grafterm-5976567557-t8z9p                  1/1     Running     0          3m31s
cray-sysmgmt-health-kube-state-metrics-77bf6847bc-ckj9k        1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-69rf7               1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-dvx7t               1/1     Running     0          3m30s
cray-sysmgmt-health-node-exporter-smartmon-f95kt               1/1     Running     0          3m31s
cray-sysmgmt-health-node-exporter-smartmon-fttwr               1/1     Running     0          3m31s
cray-sysmgmt-health-patch-nodeexporter-alerts-1-5b6rf          0/1     Completed   0          3m31s
cray-sysmgmt-health-patch-service-monitors-1-8cp6j             0/1     Completed   0          3m31s
cray-sysmgmt-health-promet-operator-5bcdd4494c-ct49j           2/2     Running     0          3m31s
cray-sysmgmt-health-prometheus-node-exporter-4knjq             1/1     Running     0          2m16s
cray-sysmgmt-health-prometheus-node-exporter-bns6x             1/1     Running     0          2m57s
cray-sysmgmt-health-prometheus-node-exporter-lfxh2             1/1     Running     0          2m33s
cray-sysmgmt-health-prometheus-node-exporter-ww4zh             1/1     Running     0          2m44s
cray-sysmgmt-health-prometheus-snmp-exporter-dbd599f47-gw8fd   1/1     Running     0          3m31s
prometheus-cray-sysmgmt-health-promet-prometheus-0             3/3     Running     1          3m13s
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

