### PR TITLE
CASMPET-5269: fix snyk issue by bumping the version

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.1
+version: 0.21.2
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/grafterm_dashboards/critical_services_dashboard.json
+++ b/kubernetes/cray-sysmgmt-health/grafterm_dashboards/critical_services_dashboard.json
@@ -3,7 +3,7 @@
   "datasources": {
     "ds": {
       "prometheus": {
-        "address": "cray-sysmgmt-health-promet-prometheus:9090"
+        "address": "http://cray-sysmgmt-health-promet-prometheus:9090"
       }
     }
   },

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -807,7 +807,7 @@ servicemonitors:
 grafterm:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-grafterm
-    tag: 1.0.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
   dashboards:
     enabled: true


### PR DESCRIPTION
## Summary and Scope
Snyk scan was reporting 3 criticals and 14 highs for the cray-grafterm image.
To resolve this we are using the golang:1.17.3-alpine3.13 version for the grafterm.

## Issues and Related PRs
https://github.com/Cray-HPE/container-images/pull/383 (merged)
https://github.com/Cray-HPE/cray-grafterm/pull/2 (merged)

* Resolves 
[CASMPET-5269](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5269)

* Change will also be needed in 
 Need to create tag for 1.2 branch after merging this PR

* Future work required:
Bump the grafterm and sysmgmt-heatlh version in csm product repo.

* Documentation changes required
None

* Merge with/before/after
None

## Testing
Done

### Tested on:
Gamora

### Test description:
Able to get the Grafterm graphs

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable


## Snapshot
### Snyk result
![image](https://user-images.githubusercontent.com/41118683/150925946-c5a5f3c3-294f-4b1f-9592-bba998ee95c0.png)

### Grafterm graphs with the latest image
![image](https://user-images.githubusercontent.com/41118683/150925916-bcfdb752-d4ba-4191-8db3-fd55b35aadad.png)

