### PR TITLE
CASMPET-5237:update  node-exporter-smartmon image reference

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.2
+version: 0.21.3
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -815,6 +815,6 @@ grafterm:
 smartmetrics:
   enabled: true
   image:
-    repository: quay.io/galexrt/node-exporter-smartmon
-    tag: v20211202-125548-659
+    repository: artifactory.algol60.net/csm-docker/stable/quay.io/galexrt/node-exporter-smartmon
+    tag: v0.1.1
     pullPolicy: IfNotPresent


### PR DESCRIPTION


Summary and Scope
Followed the objectives in CASMPET-5237.

This image has immutable upstream tag, and it is not updated with latest security patches. 
To avoid that, use patched and signed version of this image, delivered via container-images repo. 
For that, image needs to be added to container-images repo and reference in 
cray-sysmgmt-health chart changed to point to this version.

https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5237


https://github.com/Cray-HPE/container-images/pull/384



IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP ? Y

Issues and Related PRs
Resolves CASMPET-5237
Testing
Tested on:

Virtual Shasta
Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested? Y
Was a Downgrade tested? Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed the changes. Made sure the pods were all running as expected. Checked the images used by pods in the sysmgmt-health namespace to ensure they were all coming from the right place (algol60 artifactory. Logged into grafana, alertmanager, and prometheus UIs and looked around to make sure they were usable.

Risks and Mitigations
IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None


