### PR TITLE
CASMINST-4144: fix snyk issue by using the golang alpine 3.15 version

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.3
+version: 0.21.4
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -807,7 +807,7 @@ servicemonitors:
 grafterm:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-grafterm
-    tag: 1.0.1
+    tag: 1.0.2
     pullPolicy: IfNotPresent
   dashboards:
     enabled: true


### PR DESCRIPTION
## Summary and Scope
Upgrade the golang version to fix the vulnarability issue.
To resolve this we are using the golang:1.17.3-alpine3.15 version for the grafterm.

## Issues and Related PRs
https://github.com/Cray-HPE/container-images/pull/406 (merged)
https://github.com/Cray-HPE/cray-grafterm/pull/3 (merged)

* Resolves 
 [CASMINST-4144](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4144)

* Change will also be needed in 
 Need to create tag for 1.2 branch after merging this PR

* Future work required:
Bump the grafterm and sysmgmt-heatlh version in csm product repo.

* Documentation changes required
None

* Merge with/before/after
None

## Testing
Done

### Tested on:
gamora

### Test description:
Able to get the Grafterm graphs

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

### Grafterm graphs with the latest image

![image](https://user-images.githubusercontent.com/41118683/157292523-ef236d86-c3d2-4c36-a59c-eba131d7068d.png)

