### PR TITLE
CASMMON-119:CPU THROTTLING - smartmon pods

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.5
+version: 0.21.6
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
@@ -60,13 +60,6 @@ spec:
           value: "900"
         securityContext:
           privileged: true
-        resources:
-          requests:
-            cpu: 25m
-            memory: 50Mi
-          limits:
-            cpu: 80m
-            memory: 75Mi
         volumeMounts:
         - mountPath: /usr/local/sbin
           name: host-dev


### PR DESCRIPTION
## Summary and Scope

CASMMON-119: CPU THROTTLING - smartmon pods

Remove the cpu requests/limits for tsmartmon containers and rely on the defaults in the sysmgmt-health namespace

## Issues and Related PRs

* Resolves [issue id](issue link)
[CASMMON-119](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-119)
## Testing



### Tested on:

Slice 


![image](https://user-images.githubusercontent.com/22464568/158510706-89c6dc44-30b8-409c-8e29-a5adfd8780c3.png)
