### PR TITLE
CASMPET-5374: adjust istio alert rules

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.21.6
+version: 0.21.7
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/istio/istio-alerts.yaml
@@ -44,7 +44,7 @@ spec:
     - alert: IstioHigh5xxErrorRate
       annotations:
         message: 'Istio high 5xx error rate (instance "{{`{{ $labels.instance }}`}}")'
-      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.."}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 5
+      expr: sum(rate(istio_requests_total{reporter="destination", response_code=~"5.."}[5m])) / sum(rate(istio_requests_total{reporter="destination"}[5m])) * 100 > 10
       for: 1m
       labels:
         severity: warning
@@ -63,21 +63,21 @@ spec:
       annotations:
         message: 'Istio high total request rate (instance "{{`{{ $labels.instance }}`}}")'
     - alert: IstioLowTotalRequestRate
-      expr: sum(rate(istio_requests_total{reporter="destination"}[5m])) < 100
+      expr: sum(rate(istio_requests_total{reporter="destination"}[15m])) < 5
       for: 2m
       labels:
         severity: warning
       annotations:
         message: 'Istio low total request rate (instance "{{`{{ $labels.instance }}`}}")'
     - alert: IstioHighRequestLatency
-      expr: rate(istio_request_duration_milliseconds_sum[1m]) / rate(istio_request_duration_milliseconds_count[1m]) > 0.1
+      expr: rate(istio_request_duration_milliseconds_sum{reporter="destination"}[1m]) / rate(istio_request_duration_milliseconds_count{reporter="destination"}[1m]) > 100
       for: 1m
       labels:
         severity: warning
       annotations:
         message: 'Istio high request latency (instance "{{`{{ $labels.instance }}`}}")'
     - alert: IstioLatency99Percentile
-      expr: histogram_quantile(0.99, rate(istio_request_duration_milliseconds_bucket[1m])) > 1
+      expr: histogram_quantile(0.99, rate(istio_request_duration_milliseconds_bucket[1m])) > 1000
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
## Summary and Scope

The default istio alert rules have some unit errors (e.g., milliseconds vs seconds) and need adjustments in other cases. This PR will address false alarms caused by the default istio alert rules.

## Issues and Related PRs

* Resolves [CASMPET-5374]

## Testing

### Tested on:

  * `mug`

### Test description:

The istio alert rules were changed and verified on mug.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

