### PR TITLE
CASMINST-5243:cray-sysmgmt-health chart failed 

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.25.0
+version: 0.25.1
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/switch/switch-alerts.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/switch/switch-alerts.yaml
@@ -21,11 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "smartmon-alerts") }}
+{{- if and (index .Values "customRules" "create") (index .Values "customRules" "rules" "switch-alerts") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ printf "%s-%s" (include "cray-sysmgmt-health.fullname" .) "smartmon-alerts.rules" | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s" (include "cray-sysmgmt-health.fullname" .) "switch-alerts.rules" | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "cray-sysmgmt-health.name" . }}


### PR DESCRIPTION
## Summary and Scope
CASMINST-5243:cray-sysmgmt-health chart failed due to duplicate alert name
Error: prometheusrules.monitoring.coreos.com "cray-sysmgmt-health-smartmon-alerts.rules" already exists chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0
## Issues and Related PRs
https://jira-pro.its.hpecorp.net:8443/browse/CASM-3057
## Testing



### Tested on: StarLoard installation completed successfully
 loftsman ship --charts-path . --manifest-path shs-cust.yaml
2022-08-17T13:59:59Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2022-08-17T13:59:59Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2022-08-17T13:59:59Z INF Ensuring that the loftsman namespace exists command=ship
2022-08-17T13:59:59Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2022-08-17T13:59:59Z INF Running a release for the provided manifest at shs-cust.yaml command=ship
2022-08-17T14:00:00Z INF Attempting to remove previously-failed first release for cray-sysmgmt-health chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-sysmgmt-health v0.25.0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2022-08-17T14:00:06Z INF Removed previously-failed first release successfully chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0
2022-08-17T14:00:06Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.10
  - 10.252.1.11
  - 10.252.1.12
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.10
  - 10.252.1.11
  - 10.252.1.12
imageHost: registry.local
prometheus-operator:
  alertmanager:
    alertmanagerSpec:
      externalAuthority: alertmanager.cmn.starlord.dev.cray.com
      externalUrl: https://alertmanager.cmn.starlord.dev.cray.com/
  grafana:
    externalAuthority: grafana.cmn.starlord.dev.cray.com
  kubeEtcd:
    endpoints:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
  prometheus:
    prometheusSpec:
      externalAuthority: prometheus.cmn.starlord.dev.cray.com
      externalUrl: https://prometheus.cmn.starlord.dev.cray.com/
      resources:
        limits:
          cpu: "6"
          memory: 30Gi
        requests:
          cpu: "1"
          memory: 15Gi
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0
2022-08-17T14:00:06Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-sysmgmt-health-0.25.0.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=0.25.0 -f /tmp/loftsman-1660744799/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0
2022-08-17T14:00:54Z INF Release "cray-sysmgmt-health" does not exist. Installing it now.
W0817 14:00:07.063092   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0817 14:00:07.105062   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0817 14:00:07.458228   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0817 14:00:07.487092   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0817 14:00:07.536142   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
W0817 14:00:07.702534   40507 warnings.go:70] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
W0817 14:00:11.227351   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.230506   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.233512   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.236514   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.239545   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.242357   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.245055   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:11.414119   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0817 14:00:11.442647   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0817 14:00:11.470397   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W0817 14:00:11.484896   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
W0817 14:00:11.655958   40507 warnings.go:70] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
W0817 14:00:11.866406   40507 warnings.go:70] admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
W0817 14:00:12.833260   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:13.863061   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:21.982639   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.127143   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.127410   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.127992   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.128057   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.128074   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.133942   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:22.134737   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:23.257480   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W0817 14:00:23.272582   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0817 14:00:23.342271   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W0817 14:00:23.360429   40507 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
W0817 14:00:25.725489   40507 warnings.go:70] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
W0817 14:00:28.023167   40507 warnings.go:70] admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
W0817 14:00:43.219717   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:44.311718   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W0817 14:00:53.303703   40507 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME: cray-sysmgmt-health
LAST DEPLOYED: Wed Aug 17 14:00:08 2022
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 1
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=0.25.0
