### PR TITLE
CASMMON-190/196 Path change for plugins

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.0
+version: 0.26.1
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -246,6 +246,8 @@ prometheus-operator:
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana
       tag: 8.5.9
+    env:
+      GF_PATHS_PLUGINS: /var/lib/grafana-plugins 
 
     # Configure external hostname for Istio ingress
     # Setup with Ansible
@@ -265,6 +267,8 @@ prometheus-operator:
 
     # Grafana's primary configuration
     grafana.ini:
+      paths:
+        plugins: /var/lib/grafana-plugins
       analytics:
         check_for_updates: false
       # External authentication provided by Keycloak Gatekeeper and
@@ -284,11 +288,6 @@ prometheus-operator:
       datasources:
         enabled: true
         defaultDatasourceEnabled: true
-
-    # vonage-status-panel in upstream is broken and we need to install latest stable version from fork until is merged
-    plugins:
-    - grafana-piechart-panel
-    - https://github.com/MefhigosetH/Grafana_Status_panel/archive/hotfix/issue-159.zip;vonage-status-panel
 
     datasources:
       datasources.yaml:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -247,7 +247,7 @@ prometheus-operator:
       repository: artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana
       tag: 8.5.9
     env:
-      GF_PATHS_PLUGINS: /var/lib/grafana-plugins 
+      GF_PATHS_PLUGINS: /var/lib/grafana-plugins
 
     # Configure external hostname for Istio ingress
     # Setup with Ansible


### PR DESCRIPTION
[CASMMON-190](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-190) - Grafana piechart plugin issues in air-gapped systems
[CASMPET-4897](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-4897) - Grafana is missing the Vonage-status-panel plugin required by the Ceph - Cluster dashboard

Upgrading the pie-chart-panel plugin to the latest by creating a Grafana docker image with the build piechart plugin instead of downloading the piechart plugin while installing the chart. Grafana Upgrade and Dashboard improvements by supporting new visualizations. Setting the new path for plugins to download.

Resolves -
Adds pie chart panel to existing dashboards. Resolves the Grafana Ceph - Cluster dashboard reporting the following error - Panel plugin not found: Vonage-status-panel.

Tested on slice and mug systems. All the charts are working fine and have no issues. The plugins are the latest version and signed.

Screenshots -
![image](https://user-images.githubusercontent.com/110656037/191734394-ad5db5cb-b841-4490-9329-dca3a30dc0d1.png)
![image](https://user-images.githubusercontent.com/110656037/191734533-313cef60-8d5d-4687-9061-c894f93097dc.png)
![image](https://user-images.githubusercontent.com/110656037/191734631-f791f21e-19e6-46d7-91b9-742882708558.png)
![image](https://user-images.githubusercontent.com/110656037/191734748-6c45b1b6-e9ca-469b-8990-fea8c5c8053d.png)
![image](https://user-images.githubusercontent.com/110656037/191734856-15b22ccb-a363-4873-a7b6-9538bf846796.png)

