### PR TITLE
CASMMON-245 Kafka service doesn't exist to use this configuration

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.3
+version: 0.26.4
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -96,8 +96,8 @@ prometheus-operator:
 
   prometheus:
     prometheusSpec:
-      remoteWrite:
-        - url: http://prometheus-kafka-adapter.sma.svc.cluster.local:80/receive
+      #remoteWrite:
+      #  - url: http://prometheus-kafka-adapter.sma.svc.cluster.local:80/receive
       image:
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/prometheus
         tag: v2.36.1

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -96,8 +96,8 @@ prometheus-operator:
 
   prometheus:
     prometheusSpec:
-      #remoteWrite:
-      #  - url: http://prometheus-kafka-adapter.sma.svc.cluster.local:80/receive
+      # remoteWrite:
+      # - url: http://prometheus-kafka-adapter.sma.svc.cluster.local:80/receive
       image:
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/prometheus
         tag: v2.36.1


### PR DESCRIPTION
## Summary and Scope
SMA has not been installed yet so this Kafka service doesn't exist, ideally, this configuration should be patched in when SMA is installed rather than including it in CSM and causing errors to be logged until SMA is installed.

Is this change backward incompatible, backward compatible, or a backward-compatible bugfix? Yes

* Resolves -  https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-245

## Testing
_List the environments in which these changes were tested._
### Tested on:
Mug and CVM

### Test description:
- Was downgrade tested? Yes