### PR TITLE
CASMINST-5664 Prometheus error with web hook for node exporter

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.3
+version: 0.26.4
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/patch-node-exporter/patch-nodeexporter-alerts-job.yaml
@@ -27,10 +27,16 @@ kind: Job
 metadata:
   name: "{{ include "cray-sysmgmt-health.fullname" . }}-patch-nodeexporter-alerts-{{ .Release.Revision }}"
   labels:
-    app.kubernetes.io/name: {{ include "cray-sysmgmt-health.fullname" . }}-patch-nodeexporter-alerts
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-failed,before-hook-creation
 spec:
   template:
     metadata:
+      name: "{{ include "cray-sysmgmt-health.fullname" . }}-patch-nodeexporter-alerts-{{ .Release.Revision }}"
+      labels:
+{{ include "cray-sysmgmt-health.labels" . | indent 8 }}
       annotations:
         sidecar.istio.io/inject: "false"
     spec:


### PR DESCRIPTION
## Summary and Scope
Adding hook-delete-policy to delete the failed patch-nodeexporter-alerts job if it failed during installation.
This change is backward-compatible bugfix.

* Resolves [issue id](issue link)
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5664
https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5589

### Tested on:
  * `Slice`
  * Local development environment

### Test description:
- Was the upgrade tested? Yes.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable