### PR TITLE
casmpet-6097: Adjust Prometheus NCN Memory/Cpu Usage Warning Too High…

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.5
+version: 0.26.6
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/disk-space/disk-space.yaml
@@ -119,8 +119,8 @@ spec:
         severity: warning
     - alert: NodeCpuUsageTooHigh
       annotations:
-        message: 'CPU usage for NCN is above 85% (instance "{{`{{ $labels.instance }}`}}")'
-      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[10m]) * 100) * on(instance) group_left(nodename) (node_uname_info)) > 85
+        message: 'CPU usage for NCN is above 80% (instance "{{`{{ $labels.instance }}`}}")'
+      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[10m]) * 100) * on(instance) group_left(nodename) (node_uname_info)) > 80
       for: 2m
       labels:
         severity: critical
@@ -133,8 +133,8 @@ spec:
         severity: warning
     - alert: NodeMemoryUsageTooHigh
       annotations:
-        message: ' Memory usage for NCN is above 85% (instance "{{`{{ $labels.instance }}`}}") '
-      expr: 100 * (1 - ((avg_over_time(node_memory_MemFree_bytes[1h]) + avg_over_time(node_memory_Cached_bytes[1h]) + avg_over_time(node_memory_Buffers_bytes[1h])) / avg_over_time(node_memory_MemTotal_bytes[1h]))) >85
+        message: ' Memory usage for NCN is above 80% (instance "{{`{{ $labels.instance }}`}}") '
+      expr: 100 * (1 - ((avg_over_time(node_memory_MemFree_bytes[1h]) + avg_over_time(node_memory_Cached_bytes[1h]) + avg_over_time(node_memory_Buffers_bytes[1h])) / avg_over_time(node_memory_MemTotal_bytes[1h]))) >80
       for: 2m
       labels:
         severity: critical


### PR DESCRIPTION
### Summary and Scope
Master - CASMPET-6097: Adjust NCN "Memory/Cpu Usage Warning" Too High down from 85% to 80%.

NCN Memory and CPU resiliency stress testing has shown that 80% is a safer "Too High" NCN "Memory/Cpu Usage Warning" limit.
Adjust NCN "Memory/Cpu Usage Warning" Too High down from 85% to 80%.

### Issues and Related PRs
CASMPET-6097

### Testing
Tested on mug, 1.3.0-beta.58

Was a fresh Install tested? N - N/A
Was an Upgrade tested? N - N/A
Was a Downgrade tested? N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations
Low - well tested.

### Requires:
N/A