### PR TITLE
CASMMON-253:servicemonitor for argo-workflows

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.7
+version: 0.26.8
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/service-monitor.yaml
@@ -26,10 +26,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "cray-sysmgmt-health.fullname" $ }}-{{ $val.servicename }}-{{ $val.cluster }}-exporter
+  name: {{ printf "%s-%s-%s-%s" (include "cray-sysmgmt-health.fullname" $)  $val.servicename $val.cluster "exporter"  | trunc 63 | trimSuffix "-"}}
   namespace: {{ $val.serviceMonitor.namespace }}
   labels:
-    app: {{ template "cray-sysmgmt-health.name" $ }}-{{ $val.servicename }}-{{ $val.cluster }}-exporter
+    app: {{ printf "%s-%s-%s-%s" (include "cray-sysmgmt-health.fullname" $)  $val.servicename $val.cluster "exporter"  | trunc 63 | trimSuffix "-"}}
     release: {{ template "cray-sysmgmt-health.name" $ }}
 {{ include "cray-sysmgmt-health.labels" $ | indent 4 }}
 spec:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -822,6 +822,20 @@ servicemonitors:
       scheme: http
       metricsRelabelings: {}
       relabelings: {}
+  iufExporter:
+    enabled: true
+    servicename: argo-only-argo-workflows-workflow-controller
+    serviceMonitor:
+      namespace: sysmgmt-health
+      port: metrics
+      matchNamespace:
+      - argo
+      matchLabels:
+        app.kubernetes.io/name: argo-workflows-workflow-controller
+      interval: 1m
+      scheme: http
+      metricsRelabelings: {}
+      relabelings: {}
 
 grafterm:
   image:


### PR DESCRIPTION
create promethisys service monitor for argo-workflows-workflow-controller service to scrape metrics.

https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-253

Tested on Frigg:

kubectl get ServiceMonitor -n sysmgmt-health  |grep argo
cray-sysmgmt-health-argo-only-argo-workflows-workflow-controlle   35m


lift of servicemonitors  after template change
ubectl get ServiceMonitor -n sysmgmt-health
NAME                                                              AGE
cray-dns-unbound-dns-unbound-exporter                             104d
cray-sysmgmt-health-argo-only-argo-workflows-workflow-controlle   35m
cray-sysmgmt-health-bos-etcd-exporter                             104d
cray-sysmgmt-health-bss-etcd-exporter                             104d
cray-sysmgmt-health-ceph-exporter                                 104d
cray-sysmgmt-health-ceph-node-exporter                            104d
cray-sysmgmt-health-cps-etcd-exporter                             104d
cray-sysmgmt-health-crus-etcd-exporter                            104d
cray-sysmgmt-health-dhcp-kea-exporter                             104d
cray-sysmgmt-health-externaldns-etcd-exporter                     104d
cray-sysmgmt-health-fas-etcd-exporter                             104d
cray-sysmgmt-health-gitea-vcs-postgres-exporter                   104d
cray-sysmgmt-health-hbtd-etcd-exporter                            104d
cray-sysmgmt-health-hmnfd-etcd-exporter                           104d
cray-sysmgmt-health-keycloak-postgres-exporter                    104d
cray-sysmgmt-health-promet-alertmanager                           104d
cray-sysmgmt-health-promet-apiserver                              104d
cray-sysmgmt-health-promet-coredns                                104d
cray-sysmgmt-health-promet-grafana                                104d
cray-sysmgmt-health-promet-kube-controller-manager                104d
cray-sysmgmt-health-promet-kube-etcd                              104d
cray-sysmgmt-health-promet-kube-proxy                             104d
cray-sysmgmt-health-promet-kube-scheduler                         104d
cray-sysmgmt-health-promet-kube-state-metrics                     104d
cray-sysmgmt-health-promet-kubelet                                104d
cray-sysmgmt-health-promet-node-exporter                          104d
cray-sysmgmt-health-promet-operator                               104d
cray-sysmgmt-health-promet-prometheus                             104d
cray-sysmgmt-health-prometheus-snmp-exporter-sw-spine-01          104d
cray-sysmgmt-health-prometheus-snmp-exporter-sw-spine-02          104d
cray-sysmgmt-health-reds-etcd-exporter                            104d
cray-sysmgmt-health-rm-pals-postgres-exporter                     104d
cray-sysmgmt-health-sls-postgres-exporter                         104d
cray-sysmgmt-health-sma-postgres-exporter                         104d
cray-sysmgmt-health-smd-postgres-exporter                         104d
cray-sysmgmt-health-spire-postgres-exporter                       104d
cray-sysmgmt-health-spire-server                                  104d
cray-sysmgmt-health-uas-mgr-etcd-exporter                         104d
workflow-controller-metrics                                       15h


![image](https://user-images.githubusercontent.com/22464568/211736522-25271458-9f1d-40fc-a650-c8f92801e3d9.png)

