### PR TITLE
CASM-3815 & CASM-3816 Grok-exporter config and IUF timing execution time changes; minor bug fixes

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.11
+version: 0.26.12
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/grok_exporter/goss-tests.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/grok_exporter/goss-tests.json
@@ -26,8 +26,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 1860,
   "graphTooltip": 0,
-  "id": 56,
-  "iteration": 1673541997089,
+  "id": 59,
+  "iteration": 1674815873369,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -72,6 +72,7 @@
               "type": "value"
             }
           ],
+          "noValue": "Pass",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -162,6 +163,7 @@
           "mappings": [],
           "max": 10,
           "min": 0,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -207,10 +209,10 @@
           "expr": "goss_tests{Product=~\"$Product\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -288,10 +290,10 @@
           "expr": "goss_tests{Product!~\"$FailedProducts\", Result=\"PASS\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -325,6 +327,7 @@
           },
           "displayName": "Failed",
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -369,10 +372,10 @@
           "expr": "goss_tests{Product=~\"$FailedProducts\", Result=\"FAIL\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -436,7 +439,7 @@
           "calcs": [
             "sum"
           ],
-          "fields": "/^Execution_time$/",
+          "fields": "/^Value$/",
           "values": false
         },
         "text": {},
@@ -451,7 +454,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Result=~\"PASS|FAIL\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\"}) by (Product)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -470,22 +473,9 @@
           "options": {
             "include": {
               "names": [
-                "Execution_time",
-                "Product"
+                "Value"
               ]
             }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
           }
         }
       ],
@@ -503,7 +493,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "center",
+            "align": "left",
             "displayMode": "color-text",
             "filterable": true,
             "inspect": false
@@ -536,7 +526,32 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Result"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 523
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Product"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 521
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
@@ -565,13 +580,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product!~\"$FailedProducts\", Result=~\"PASS\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\",Product=~\"$FailedProducts\",Result=\"FAIL\"}) by (Product, Result)",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 1,
-          "legendFormat": "__auto",
-          "range": true,
+          "legendFormat": "",
+          "range": false,
           "refId": "A",
           "step": 900
         },
@@ -581,23 +596,43 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "goss_tests{Product=~\"$FailedProducts\", Result=~\"FAIL\"}",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\",Product!~\"$FailedProducts\",Result=\"PASS\"}) by (Product, Result)",
           "format": "table",
           "hide": false,
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\"}) by (Product)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "range": false,
+          "refId": "C"
         }
       ],
       "title": "Products detail",
       "transformations": [
         {
+          "id": "merge",
+          "options": {}
+        },
+        {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "Execution_time",
                 "Product",
-                "Result"
+                "Result",
+                "Value #C"
               ]
             }
           }
@@ -613,56 +648,8 @@
             },
             "renameByName": {
               "Execution_time": "",
-              "Product": ""
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "dateFormat": "seconds",
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "Execution_time": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Execution_time_failed_test": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Execution_time_for_failed_tests": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Product": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Result": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Value": {
-                "aggregations": []
-              }
+              "Product": "",
+              "Value #C": "Execution Time"
             }
           }
         }
@@ -791,7 +778,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "The number of suites that ran the goss tests, Number of products that failed, and Number of products that passed.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -845,10 +832,10 @@
           "expr": "goss_tests{Product=~\"$Product\",Suite=~\"$Suite\", Result=~\"PASS|FAIL\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -927,10 +914,10 @@
           "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Suite!~\"$FailedSuites\", Result=\"PASS\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -1009,10 +996,10 @@
           "expr": "goss_tests{Product=~\"$Product\",Suite=~\"$FailedSuites\", Result=\"FAIL\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -1076,7 +1063,7 @@
           "calcs": [
             "sum"
           ],
-          "fields": "/^Execution_time$/",
+          "fields": "/^Value$/",
           "values": false
         },
         "text": {},
@@ -1091,7 +1078,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Result=~\"PASS|FAIL\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\", Suite=~\"$Suite\"}) by (Suite)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1110,22 +1097,10 @@
           "options": {
             "include": {
               "names": [
-                "Execution_time",
-                "Suite"
+                "Suite",
+                "Value"
               ]
             }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
           }
         }
       ],
@@ -1185,7 +1160,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 158
+                "value": 415
               }
             ]
           },
@@ -1232,11 +1207,13 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Suite=~\"$FailedSuites\", Result=~\"FAIL\"}",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Suite=~\"$FailedSuites\",Result=\"FAIL\"}) by (Suite, Result)",
           "format": "table",
           "hide": false,
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         },
         {
@@ -1246,15 +1223,30 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Suite!~\"$FailedSuites\", Result=~\"PASS\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Suite!~\"$FailedSuites\",Result=\"PASS\"}) by (Suite, Result)",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 1,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "B",
           "step": 900
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\", Suite=~\"$Suite\"}) by (Suite)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
         }
       ],
       "title": "Suites detail",
@@ -1268,47 +1260,10 @@
           "options": {
             "include": {
               "names": [
-                "Execution_time",
-                "Node",
                 "Result",
-                "Suite"
+                "Suite",
+                "Value #C"
               ]
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "Execution_time": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Node": {
-                "aggregations": []
-              },
-              "Result": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Suite": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
             }
           }
         },
@@ -1323,7 +1278,8 @@
               "Suite": 0
             },
             "renameByName": {
-              "Source": "Suite"
+              "Source": "Suite",
+              "Value #C": "Execution time"
             }
           }
         }
@@ -1665,10 +1621,10 @@
           "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$FailedTests\", Result=\"FAIL\"}",
           "format": "table",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 2,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "step": 240
         }
@@ -1725,14 +1681,14 @@
       "links": [],
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "sum"
           ],
-          "fields": "/^Execution_time$/",
+          "fields": "/^Value$/",
           "values": false
         },
         "text": {},
@@ -1747,7 +1703,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Test_name=~\"$Test\",Result=~\"PASS|FAIL\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\", Suite=~\"$Suite\",Test_name=~\"$Test\"}) by (Test_name)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1766,22 +1722,10 @@
           "options": {
             "include": {
               "names": [
-                "Execution_time",
-                "Test_name"
+                "Test_name",
+                "Value"
               ]
             }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
           }
         }
       ],
@@ -1832,7 +1776,32 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Test name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 666
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Result"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 419
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1851,7 +1820,8 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "8.5.9",
       "targets": [
@@ -1862,7 +1832,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$FailedTests\", Result=\"FAIL\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Test_name=~\"$Test\",Test_name=~\"$FailedTests\",Result=\"FAIL\"}) by (Test_name, Result)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1879,12 +1849,28 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Test_name!~\"$FailedTests\", Result=\"PASS\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Test_name=~\"$Test\",Test_name!~\"$FailedTests\",Result=\"PASS\"}) by (Test_name, Result)",
           "format": "table",
           "hide": false,
           "instant": true,
+          "legendFormat": "__auto",
           "range": false,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\", Suite=~\"$Suite\",Test_name=~\"$Test\"}) by (Test_name)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
         }
       ],
       "title": "Test detail",
@@ -1898,10 +1884,9 @@
           "options": {
             "include": {
               "names": [
-                "Execution_time",
-                "Node",
                 "Result",
-                "Test_name"
+                "Test_name",
+                "Value #C"
               ]
             }
           }
@@ -1918,43 +1903,8 @@
             },
             "renameByName": {
               "Execution_time": "",
-              "Test_name": ""
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "Execution_time": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Node": {
-                "aggregations": []
-              },
-              "Result": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Test_name": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
+              "Test_name": "Test name",
+              "Value #C": "Test execution time"
             }
           }
         }
@@ -2029,10 +1979,12 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Test_name=~\"$FailedTests\", Node=~\"$Node\", Result=\"FAIL\"}",
           "format": "table",
-          "legendFormat": "FAILED",
-          "range": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -2131,10 +2083,12 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
+          "exemplar": false,
           "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Test_name!~\"$FailedTests\", Node=~\"$Node\", Result=\"PASS\"}",
           "format": "table",
-          "legendFormat": "FAILED",
-          "range": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -2200,11 +2154,13 @@
               "options": {
                 "FAIL": {
                   "color": "red",
-                  "index": 1
+                  "index": 1,
+                  "text": "Failed"
                 },
                 "PASS": {
                   "color": "green",
-                  "index": 0
+                  "index": 0,
+                  "text": "Passed"
                 }
               },
               "type": "value"
@@ -2277,7 +2233,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Node=~\"$Node\", Result=~\"PASS|FAIL\"}",
+          "expr": "sum(goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Node=~\"$Node\"}) by (Node,Test_summary,Result)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2286,19 +2242,38 @@
           "range": false,
           "refId": "A",
           "step": 900
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\",Suite=~\"$Suite\",Test_name=~\"$Test\",Node=~\"$Node\"}) by (Node,Test_summary,Result)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
         }
       ],
       "title": "Node-wise test result",
       "transformations": [
         {
+          "id": "merge",
+          "options": {}
+        },
+        {
           "id": "filterFieldsByName",
           "options": {
             "include": {
               "names": [
-                "Execution_time",
                 "Node",
                 "Result",
-                "Test_summary"
+                "Test_summary",
+                "Value #B"
               ]
             }
           }
@@ -2315,48 +2290,9 @@
             },
             "renameByName": {
               "Execution_time": "",
-              "Test_name": ""
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Execution_time"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "groupBy",
-          "options": {
-            "fields": {
-              "Execution_time": {
-                "aggregations": [
-                  "sum"
-                ],
-                "operation": "aggregate"
-              },
-              "Node": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Result": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Test_name": {
-                "aggregations": [],
-                "operation": "groupby"
-              },
-              "Test_summary": {
-                "aggregations": [],
-                "operation": "groupby"
-              }
+              "Test_name": "",
+              "Test_summary": "Test Summary",
+              "Value #B": "Execution time"
             }
           }
         }
@@ -2375,6 +2311,11 @@
             "fixedColor": "text",
             "mode": "fixed"
           },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -2387,10 +2328,23 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Test name"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 334
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
+        "h": 9,
         "w": 24,
         "x": 0,
         "y": 55
@@ -2398,18 +2352,15 @@
       "id": 352,
       "links": [],
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "uniqueValues"
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^Description$/",
-          "values": false
+          "show": false
         },
-        "textMode": "auto"
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "8.5.9",
       "targets": [
@@ -2420,7 +2371,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Node=~\"$Node\", Result=~\"PASS|FAIL\"}",
+          "expr": "goss_tests{Product=~\"$Product\", Suite=~\"$Suite\", Test_name=~\"$Test\", Node=~\"$Node\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2438,13 +2389,28 @@
           "options": {
             "include": {
               "names": [
+                "Test_name",
                 "Description"
               ]
             }
           }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "Description": 1,
+              "Test_name": 0
+            },
+            "renameByName": {
+              "Description": "Test description",
+              "Test_name": "Test name"
+            }
+          }
         }
       ],
-      "type": "stat"
+      "type": "table"
     }
   ],
   "refresh": "",
@@ -2457,9 +2423,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "None",
-          "value": ""
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -2467,7 +2433,7 @@
         },
         "definition": "label_values(goss_tests, Product)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "product",
         "multi": false,
         "name": "Product",
@@ -2680,7 +2646,7 @@
   },
   "timezone": "browser",
   "title": "Goss tests",
-  "uid": "LATEST",
-  "version": 3,
+  "uid": "Goss",
+  "version": 1,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/iuf/iuf-timing-dashboard.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/iuf/iuf-timing-dashboard.json
@@ -25,8 +25,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 1860,
   "graphTooltip": 0,
-  "id": 58,
-  "iteration": 1673953453378,
+  "id": 1,
+  "iteration": 1674811231019,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -396,14 +396,13 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Time to execute the test for the product selected",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "orange",
             "mode": "fixed"
           },
-          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -433,9 +432,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "sum"
+            "firstNotNull"
           ],
-          "fields": "/^Value$/",
+          "fields": "/^Exec$/",
           "values": false
         },
         "text": {},
@@ -450,7 +449,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "argo_workflows_operation_counter{pname=~\"$Product\"}",
+          "expr": "argo_workflows_operation_time{pdname=~\"$Product\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -462,17 +461,32 @@
           "step": 900
         }
       ],
-      "title": "Total execution time for product",
+      "title": "Execution time for product selected",
       "transformations": [
         {
-          "id": "filterFieldsByName",
+          "id": "reduce",
           "options": {
-            "include": {
-              "names": [
-                "Value",
-                "opend",
-                "opname"
-              ]
+            "includeTimeField": false,
+            "mode": "reduceFields",
+            "reducers": [
+              "max",
+              "min"
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Exec",
+            "binary": {
+              "left": "opend Max",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "opstart Min"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
             }
           }
         }
@@ -584,35 +598,15 @@
           "options": {}
         },
         {
-          "id": "convertFieldType",
+          "id": "filterFieldsByName",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Value #A"
-              },
-              {
-                "destinationType": "number",
-                "targetField": "Value #B"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Time",
-            "binary": {
-              "left": "Value #A",
-              "reducer": "sum",
-              "right": "Value #B"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
+            "include": {
+              "names": [
+                "pname",
+                "status",
+                "Value #C"
+              ]
+            }
           }
         },
         {
@@ -623,20 +617,9 @@
             "renameByName": {
               "Time": "Time",
               "Value": "Time",
+              "Value #C": "Time taken",
               "pname": "Product",
               "status": "Status"
-            }
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Product",
-                "Status",
-                "Time 2"
-              ]
             }
           }
         }
@@ -1012,7 +995,6 @@
             "fixedColor": "orange",
             "mode": "fixed"
           },
-          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1033,18 +1015,18 @@
         "x": 19,
         "y": 12
       },
-      "id": 20,
+      "id": 364,
       "links": [],
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "justifyMode": "center",
+        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "sum"
+            "firstNotNull"
           ],
-          "fields": "/^Value$/",
+          "fields": "/^Exec$/",
           "values": false
         },
         "text": {},
@@ -1059,42 +1041,46 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "argo_workflows_operation_counter{pname=~\"$Product\", stage=~\"$Stage\"}",
+          "expr": "argo_workflows_operation_time{pdname=~\"$Product\", stage=~\"$Stage\"}",
           "format": "table",
           "hide": false,
           "instant": true,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "__auto",
           "range": false,
           "refId": "A",
           "step": 900
         }
       ],
-      "title": "Total execution time for stage",
+      "title": "Execution time for stage selected",
       "transformations": [
         {
-          "id": "filterFieldsByName",
+          "id": "reduce",
           "options": {
-            "include": {
-              "names": [
-                "Value",
-                "stage",
-                "pdname"
-              ]
-            }
+            "includeTimeField": false,
+            "labelsToFields": true,
+            "mode": "reduceFields",
+            "reducers": [
+              "max",
+              "min"
+            ]
           }
         },
         {
-          "id": "convertFieldType",
+          "id": "calculateField",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Value"
-              }
-            ],
-            "fields": {}
+            "alias": "Exec",
+            "binary": {
+              "left": "opend Max",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "opstart Min"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
           }
         }
       ],
@@ -1105,7 +1091,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "List of stages with it's status and execution test",
+      "description": "List of stages with its status and time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1205,35 +1191,15 @@
           "options": {}
         },
         {
-          "id": "convertFieldType",
+          "id": "filterFieldsByName",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Value #A"
-              },
-              {
-                "destinationType": "number",
-                "targetField": "Value #B"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Time",
-            "binary": {
-              "left": "Value #A",
-              "reducer": "sum",
-              "right": "Value #B"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
+            "include": {
+              "names": [
+                "stage",
+                "status",
+                "Value #C"
+              ]
+            }
           }
         },
         {
@@ -1245,21 +1211,10 @@
               "Time": "Time",
               "Time 2": "",
               "Value": "Time",
+              "Value #C": "Time taken",
               "pname": "Product",
               "stage": "Stage",
               "status": "Status"
-            }
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Stage",
-                "Status",
-                "Time 2"
-              ]
             }
           }
         }
@@ -1627,7 +1582,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Time to execute the selected test",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1655,12 +1610,12 @@
         "x": 19,
         "y": 23
       },
-      "id": 330,
+      "id": 20,
       "links": [],
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "justifyMode": "auto",
+        "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -1681,7 +1636,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "argo_workflows_operation_counter{pname=~\"$Product\", stage=~\"$Stage\", opname=~\"$Operation\"}",
+          "expr": "argo_workflows_operation_time{pdname=~\"$Product\", stage=~\"$Stage\", opname=~\"$Operation\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1693,7 +1648,7 @@
           "step": 900
         }
       ],
-      "title": "Total execution time for operation",
+      "title": "Execution time for operation selected",
       "transformations": [
         {
           "id": "filterFieldsByName",
@@ -1701,9 +1656,7 @@
             "include": {
               "names": [
                 "Value",
-                "pdname",
-                "opname",
-                "stage"
+                "opname"
               ]
             }
           }
@@ -1728,7 +1681,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "List of Operation with it's status and execution test",
+      "description": "List of Operations with its status and time",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1771,7 +1724,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 7,
         "w": 24,
         "x": 0,
         "y": 28
@@ -1798,7 +1751,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(argo_workflows_operation_counter{pname=~\"$Product\", opname=~\"$FailedOperations\", status=\"Failed\"}) by (status, opname)",
+          "expr": "sum(argo_workflows_operation_counter{pname=~\"$Product\",stage=~\"$Stage\",opname=~\"$FailedOperations\",status=\"Failed\"}) by (status, opname)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1812,13 +1765,28 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(argo_workflows_operation_counter{pname=~\"$Product\", opname!~\"$FailedOperations\", status=~\"Succeeded\"}) by (status, opname)",
+          "expr": "sum(argo_workflows_operation_counter{pname=~\"$Product\",stage=~\"$Stage\",opname!~\"$FailedOperations\",status=~\"Succeeded\"}) by (status, opname)",
           "format": "table",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(argo_workflows_operation_time{pdname=~\"$Product\",stage=~\"$Stage\",opname=~\"$Operation\"}) by (opname)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
         }
       ],
       "title": "Operation detail",
@@ -1828,35 +1796,15 @@
           "options": {}
         },
         {
-          "id": "convertFieldType",
+          "id": "filterFieldsByName",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Value #A"
-              },
-              {
-                "destinationType": "number",
-                "targetField": "Value #B"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Time",
-            "binary": {
-              "left": "Value #A",
-              "reducer": "sum",
-              "right": "Value #B"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "replaceFields": false
+            "include": {
+              "names": [
+                "opname",
+                "status",
+                "Value #C"
+              ]
+            }
           }
         },
         {
@@ -1865,24 +1813,9 @@
             "excludeByName": {},
             "indexByName": {},
             "renameByName": {
-              "Time": "Time",
-              "Time 2": "",
-              "Value": "Time",
-              "pname": "Product",
-              "stage": "Stage",
+              "Value #C": "Time taken",
+              "opname": "Operation Name",
               "status": "Status"
-            }
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Status",
-                "Time 2",
-                "opname"
-              ]
             }
           }
         }
@@ -1926,7 +1859,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 35
       },
       "id": 360,
       "options": {
@@ -1996,7 +1929,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -2194,6 +2127,6 @@
   "timezone": "browser",
   "title": "IUF Timing Dashboard",
   "uid": "Timing",
-  "version": 24,
+  "version": 4,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/templates/grok-exporter/config-map.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grok-exporter/config-map.yaml
@@ -50,16 +50,17 @@ data:
       - type: gauge
         name: goss_tests
         help: GOSS TESTS
-        match: '{"log_timestamp": "%{TIMESTAMP:tstmp}", "Product": "%{PRODUCT:prod}", "log_script": "%{SCRIPT:scrip}", "log_message": "Test result", "Description": "%{DESC:desc}", "Execution Time \(raw\)": %{NUM:raw}, "Execution Time \(seconds\)": %{NUM:time}, "Node": "%{NODE:node}", "Result Code": %{CODE:code}, "Result String": "%{RESULT:res}", "Source": ".*\/%{SUITE:suite}", "Test Name": "%{DESC:name}", "Test Summary": "%{DESC:sum}"}'
-        value: '{{`{{.code}}`}}'
+        match: '{"log_timestamp": "%{TIMESTAMP:tstmp}", "Product": "%{PRODUCT:prod}", "log_script": "%{SCRIPT:scrip}", "log_message": "Test result", "Description": "%{DESC:desc}", "Execution Time \(nanoseconds\)": %{NUM:ns}, "Execution Time \(seconds\)": %{TIME:time}, "Node": "%{NODE:node}", "Result Code": %{CODE:code}, "Result String": "%{RESULT:res}", "Source": ".*\/%{SUITE:suite}", "Test Name": "%{DESC:name}", "Test Summary": "%{DESC:sum}"}'
+        value: '{{`{{.time}}`}}'
         labels:
           Timestamp: '{{`{{.tstmp}}`}}'
           Product: '{{`{{.prod}}`}}'
           Script: '{{`{{.scrip}}`}}'
           Description: '{{`{{.desc}}`}}'
-          Execution_raw: '{{`{{.raw}}`}}'
+          Execution_raw: '{{`{{.ns}}`}}'
           Execution_time: '{{`{{.time}}`}}'
           Node: '{{`{{.node}}`}}'
+          Code: '{{`{{.code}}`}}'
           Result: '{{`{{.res}}`}}'
           Suite: '{{`{{.suite}}`}}'
           Test_name: '{{`{{.name}}`}}'


### PR DESCRIPTION
## Summary and Scope

_Changes in grok exporter configuration as goss tests logs format is changed. We do not want to use scientific notation as the calculation is wrong on Grafana. Hence, when logging test duration is changed to seconds._

_Calculation of execution time for IUF product and IUF stage using the difference of maximum and minimum of operation end and operation start respectively instead of sum in IUF timing dashboard._

_Change is a backward compatible bugfix._

## Issues and Related PRs

Resolves -
[CASM-3815](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3815)
[CASM-3816](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3816)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `frigg`
  * Local development environment
  * Virtual Shasta

### Test description:

_Changes tested and successfully verified._

- Install/upgrade-based validation by running goss tests performed.
- Upgrade is tested.

![image](https://user-images.githubusercontent.com/110656037/215101870-8c268550-d481-4087-942b-4387ae266acf.png)
![image](https://user-images.githubusercontent.com/110656037/215101950-27acbf76-274e-4b65-bdc5-d1ea9dd354a0.png)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable