### PR TITLE
CASM-3854 Grok-exporter to be scheduled on all master nodes. Sorting order of operations based on installation time in IUF and log time panel in goss dashboards.

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.12
+version: 0.26.13
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/grok_exporter/goss-tests.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/grok_exporter/goss-tests.json
@@ -26,8 +26,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 1860,
   "graphTooltip": 0,
-  "id": 59,
-  "iteration": 1674815873369,
+  "id": 10,
+  "iteration": 1675311447518,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -61,12 +61,12 @@
                 "FAIL": {
                   "color": "red",
                   "index": 0,
-                  "text": "Fail"
+                  "text": "Failed"
                 },
                 "PASS": {
                   "color": "green",
                   "index": 1,
-                  "text": "Pass"
+                  "text": "Passed"
                 }
               },
               "type": "value"
@@ -91,7 +91,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 4,
         "x": 0,
         "y": 1
@@ -178,7 +178,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 4,
         "y": 1
@@ -259,7 +259,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 9,
         "y": 1
@@ -341,7 +341,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 14,
         "y": 1
@@ -423,7 +423,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 19,
         "y": 1
@@ -535,7 +535,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 523
+                "value": 226
               }
             ]
           },
@@ -547,7 +547,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 521
+                "value": 362
               }
             ]
           }
@@ -555,9 +555,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 24,
+        "w": 14,
         "x": 0,
-        "y": 7
+        "y": 6
       },
       "id": 318,
       "links": [],
@@ -657,12 +657,110 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeAsUS"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 10,
+        "x": 14,
+        "y": 6
+      },
+      "id": 361,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "first"
+          ],
+          "fields": "/^Timestamp$/",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(goss_tests{Product=~\"$Product\"}) by (Product, Timestamp)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "step": 900
+        }
+      ],
+      "title": "Timestamp of the test log",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Timestamp"
+              ]
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "Timestamp"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 10
       },
       "id": 324,
       "panels": [],
@@ -686,12 +784,12 @@
                 "FAIL": {
                   "color": "red",
                   "index": 1,
-                  "text": "Fail"
+                  "text": "Failed"
                 },
                 "PASS": {
                   "color": "green",
                   "index": 0,
-                  "text": "Pass"
+                  "text": "Passed"
                 }
               },
               "type": "value"
@@ -716,10 +814,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 4,
         "x": 0,
-        "y": 12
+        "y": 11
       },
       "id": 319,
       "links": [],
@@ -801,10 +899,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 4,
-        "y": 12
+        "y": 11
       },
       "id": 349,
       "links": [],
@@ -883,10 +981,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 9,
-        "y": 12
+        "y": 11
       },
       "id": 339,
       "links": [],
@@ -965,10 +1063,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 14,
-        "y": 12
+        "y": 11
       },
       "id": 343,
       "links": [],
@@ -1047,10 +1145,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 19,
-        "y": 12
+        "y": 11
       },
       "id": 20,
       "links": [],
@@ -1182,7 +1280,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 16
       },
       "id": 357,
       "links": [],
@@ -1292,7 +1390,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 24
       },
       "id": 328,
       "panels": [],
@@ -1342,10 +1440,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 4,
         "x": 0,
-        "y": 27
+        "y": 25
       },
       "id": 329,
       "links": [],
@@ -1426,10 +1524,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 4,
-        "y": 27
+        "y": 25
       },
       "id": 344,
       "links": [],
@@ -1508,10 +1606,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 9,
-        "y": 27
+        "y": 25
       },
       "id": 345,
       "links": [],
@@ -1590,10 +1688,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 14,
-        "y": 27
+        "y": 25
       },
       "id": 346,
       "links": [],
@@ -1672,10 +1770,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 5,
         "x": 19,
-        "y": 27
+        "y": 25
       },
       "id": 330,
       "links": [],
@@ -1807,7 +1905,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 30
       },
       "id": 358,
       "links": [],
@@ -1917,7 +2015,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 38
       },
       "id": 336,
       "panels": [],
@@ -1958,7 +2056,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 39
       },
       "id": 359,
       "options": {
@@ -2062,7 +2160,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 39
       },
       "id": 360,
       "options": {
@@ -2208,7 +2306,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 44
       },
       "id": 334,
       "links": [],
@@ -2347,7 +2445,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 52
       },
       "id": 352,
       "links": [],
@@ -2423,7 +2521,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/iuf/iuf-timing-dashboard.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/iuf/iuf-timing-dashboard.json
@@ -25,8 +25,8 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 1860,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1674811231019,
+  "id": 3,
+  "iteration": 1675314772016,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1252,8 +1252,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1346,8 +1345,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1432,8 +1430,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1514,8 +1511,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1595,8 +1591,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1714,8 +1709,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1842,8 +1836,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1937,7 +1930,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(argo_workflows_operation_counter, pname)",
+        "definition": "label_values(argo_workflows_operation_time, pdname)",
         "hide": 0,
         "includeAll": true,
         "label": "Product",
@@ -1945,7 +1938,7 @@
         "name": "Product",
         "options": [],
         "query": {
-          "query": "label_values(argo_workflows_operation_counter, pname)",
+          "query": "label_values(argo_workflows_operation_time, pdname)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1964,7 +1957,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(argo_workflows_operation_counter{pname=~\"$Product\"}, stage)",
+        "definition": "label_values(argo_workflows_operation_time{pdname=~\"$Product\"}, stage)",
         "hide": 0,
         "includeAll": true,
         "label": "Stage",
@@ -1972,7 +1965,7 @@
         "name": "Stage",
         "options": [],
         "query": {
-          "query": "label_values(argo_workflows_operation_counter{pname=~\"$Product\"}, stage)",
+          "query": "label_values(argo_workflows_operation_time{pdname=~\"$Product\"}, stage)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1983,7 +1976,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -1991,7 +1984,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(argo_workflows_operation_counter{pname=~\"$Product\", stage=~\"$Stage\"}, opname)",
+        "definition": "label_values(argo_workflows_operation_time{pdname=~\"$Product\", stage=~\"$Stage\"}, opname)",
         "hide": 0,
         "includeAll": true,
         "label": "Operation",
@@ -1999,7 +1992,7 @@
         "name": "Operation",
         "options": [],
         "query": {
-          "query": "label_values(argo_workflows_operation_counter{pname=~\"$Product\", stage=~\"$Stage\"}, opname)",
+          "query": "label_values(argo_workflows_operation_time{pdname=~\"$Product\", stage=~\"$Stage\"}, opname)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2127,6 +2120,6 @@
   "timezone": "browser",
   "title": "IUF Timing Dashboard",
   "uid": "Timing",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
@@ -29,7 +29,7 @@ metadata:
     app: grok-exporter
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: grok-exporter
@@ -47,6 +47,16 @@ spec:
                 operator: In
                 values:
                 - ncn-m001
+            - matchFields:
+              - key: metadata.name
+                operator: In
+                values:
+                - ncn-m002
+            - matchFields:
+              - key: metadata.name
+                operator: In
+                values:
+                - ncn-m003
       containers:
         - name: grok-exporter
           image: artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest


### PR DESCRIPTION
## Summary and Scope

`cray-sysmgmt-health-grok-exporter` is currently scheduled only on `ncn-m001` master node based on a few pieces of documentation suggesting goss tests are run on `ncn-m001`. Found out that the service needs to be available on `ncn-m002` and `ncn-m003` as well for parsing the goss test result logs if they are run on these masters based on conversation with @mharding-hpe.

This PR modifies the deployment of grok-exporter to have the grok-exporter instances on all masters  - m001, m002 and m003.

Added order of dropdowns for products/ stages/operations based on installation time in IUF timing dashboard.

Added another panel in the goss test dashboard to check the log timestamp.

## Issues and Related PRs

* Resolves [CASM-3854](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3854)
* Change will also be needed in `<release-1.4 or release-1.6>`
* Documentation changes made in [CASMINST-5893](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5893)

## Testing
_List the environments in which these changes were tested._
### Tested on:
  * `frigg`
  * Local development environment
  * Virtual Shasta

### Test description:

The changes were tested and success verified.
ncn-m001:/mnt/developer/sum/goss # kubectl get all -l app=grok-exporter -n sysmgmt-health -o wide
NAME                                                   READY   STATUS    RESTARTS   AGE     IP          NODE       NOMINATED NODE   READINESS GATES
pod/cray-sysmgmt-health-grok-exporter-d68865c8-p52nz   1/1     Running   0          3m12s   10.44.0.6   ncn-m003   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-d68865c8-pfzcf   1/1     Running   0          3m12s   10.32.0.8   ncn-m002   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-d68865c8-sc49l   1/1     Running   0          15h     10.34.0.4   ncn-m001   <none>           <none>

NAME                                        TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE   SELECTOR
service/cray-sysmgmt-health-grok-exporter   ClusterIP   10.25.105.12   <none>        9144/TCP   18h   app=grok-exporter

NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS      IMAGES                                                                                   SELECTOR
deployment.apps/cray-sysmgmt-health-grok-exporter   3/3     3            3           18h   grok-exporter   artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest   app=grok-exporter

NAME                                                         DESIRED   CURRENT   READY   AGE   CONTAINERS      IMAGES                                                                                   SELECTOR
replicaset.apps/cray-sysmgmt-health-grok-exporter-d68865c8   3         3         3       15h   grok-exporter   artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest   app=grok-exporter,pod-template-hash=d68865c8


![image](https://user-images.githubusercontent.com/110656037/216277219-9a47019d-cb01-4e24-958f-76774470ae69.png)
![image](https://user-images.githubusercontent.com/110656037/216277545-ed6c476c-5ddc-465f-a925-ae95cbb65bc5.png)

-  Upgrade is tested.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable