### PR TITLE
CASMMON-289: Prometheus image not present

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.27.1
+version: 0.27.2
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -103,7 +103,8 @@ kube-prometheus-stack:
       remoteWrite:
         - url: http://prometheus-kafka-adapter.sma.svc.cluster.local:80/receive
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/prometheus
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/quay.io/prometheus/prometheus
         tag: v2.41.0
       # Enable administrative HTTP API, 'cause why not?
       enableAdminAPI: true


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-289

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves- https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-289

## Testing

### Tested on:

hela

### Logs

Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Scheduled               15m                default-scheduler        Successfully assigned sysmgmt-health/prometheus-cray-sysmgmt-heal               th-kube-p-prometheus-0 to ncn-w001
  Normal   SuccessfulAttachVolume  15m                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-d870ccdc-5b82-4cf4-               b62b-ee793fc6c116"
  Normal   Pulled                  15m                kubelet                  Container image "artifactory.algol60.net/csm-docker/stable/docker               .io/prom/prometheus-config-reloader:v0.62.0" already present on machine
  Normal   Created                 15m                kubelet                  Created container init-config-reloader
  Normal   Started                 15m                kubelet                  Started container init-config-reloader
  Normal   Pulled                  15m                kubelet                  Container image "artifactory.algol60.net/csm-docker/stable/quay.i               o/prometheus/prometheus:v2.41.0" already present on machine
  Normal   Created                 15m                kubelet                  Created container prometheus
  Normal   Started                 15m                kubelet                  Started container prometheus
  Normal   Pulled                  15m                kubelet                  Container image "artifactory.algol60.net/csm-docker/stable/docker               .io/prom/prometheus-config-reloader:v0.62.0" already present on machine
  Normal   Created                 15m                kubelet                  Created container config-reloader
  Normal   Started                 15m                kubelet                  Started container config-reloader
  Warning  Unhealthy               15m (x3 over 15m)  kubelet                  Startup probe failed: HTTP probe failed with statuscode: 503
