### PR TITLE
CASMMON-299 Grok-exporter issue with running on ncn-m001 Release/1.4

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.21
+version: 0.26.22
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
@@ -33,6 +33,11 @@ spec:
   selector:
     matchLabels:
       app: grok-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 35%
+      maxUnavailable: 35%
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -57,6 +62,15 @@ spec:
                 operator: In
                 values:
                 - ncn-m003
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - grok-exporter
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: grok-exporter
           image: artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest


### PR DESCRIPTION
## Summary and Scope

_Grok-exporter is not running on ncn-m001 as it comes up last when nodes are installed on pit. The other master nodes of m002 or m003 is taking ownership of the m001 instance before it is up._

_This fix will resolve the issue and wait for m001 to take the ownership of the pod._

## Issues and Related PRs

* Resolves [CASMMON-299](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-299)

## Testing

### Tested on:

  * `<mug>`
  * `<hela>`
  * Local development environment
  * Virtual Shasta

### Test description:

_Tested and success verified._
ncn-m001:/mnt/developer/sum # kubectl get all -n sysmgmt-health | grep grok
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-2cc8z              1/1     Running            0          3m34s
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-htsps              1/1     Running            0          3m35s
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-khrhs              1/1     Running            0          3m35s
service/cray-sysmgmt-health-grok-exporter              ClusterIP   10.18.245.121   <none>        9144/TCP                     2d17h
deployment.apps/cray-sysmgmt-health-grok-exporter              3/3     3            3           2d17h
replicaset.apps/cray-sysmgmt-health-grok-exporter-6b64849ff5              3         3         3       3m35s
replicaset.apps/cray-sysmgmt-health-grok-exporter-d68865c8                0         0         0       2d17h

ncn-m001:/mnt/developer/sum # kubectl get pod -n sysmgmt-health -o wide | grep grok-exporter
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-2cc8z              1/1     Running            0          4m3s    10.32.0.5     ncn-m003   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-htsps              1/1     Running            0          4m4s    10.33.128.0   ncn-m001   <none>           <none>
pod/cray-sysmgmt-health-grok-exporter-6b64849ff5-khrhs              1/1     Running            0          4m4s    10.35.0.0     ncn-m002   <none>           <none>

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
