### PR TITLE
CASMMON-322 jettech/kube-webhook-certgen:v1.3.0 doesn't work with k8s 1.22 - main

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.27.10
+version: 0.28.0
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -88,7 +88,7 @@ kube-prometheus-stack:
         enabled: true
         image:
           registry: artifactory.algol60.net
-          repository: csm-docker/stable/docker.io/jettech/kube-webhook-certgen
+          repository: csm-docker/stable/registry.k8s.io/ingress-nginx/kube-webhook-certgen
           tag: v1.3.0
           pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Summary and Scope
cray-sysmgmt-health fails to install on k8s 1.22 using jettech/kube-webhook-certgen:v1.3.0 as well.

This PR uses the registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0 to fix it.

Issues and Related PRs
[CASMMON-322](https://jira-pro.it.hpe.com:8443/browse/CASMMON-322)
Implementation of the registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0 image.

Tested on vShasta Ashton system.

All images and chart gets deployed without issues -
```
Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       65s   default-scheduler  Successfully assigned sysmgmt-health/cray-sysmgmt-health-kube-p-admission-patch-qjkcb to ncn-w003
  Normal  AddedInterface  65s   multus             Add eth0 [10.40.0.76/12] from weave
  Normal  Pulling         64s   kubelet            Pulling image "[artifactory.algol60.net/csm-docker/stable/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0](http://artifactory.algol60.net/csm-docker/stable/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0)"
  Normal  Pulled          61s   kubelet            Successfully pulled image "[artifactory.algol60.net/csm-docker/stable/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0](http://artifactory.algol60.net/csm-docker/stable/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0)" in 2.898821948s
  Normal  Created         61s   kubelet            Created container patch
  Normal  Started         61s   kubelet            Started container patch
```

```
kubectl logs -n sysmgmt-health cray-sysmgmt-health-kube-p-admission-patch-qjkcb
W0612 14:59:11.405388       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"level":"info","msg":"patching webhook configurations 'cray-sysmgmt-health-kube-p-admission' mutating=true, validating=true, failurePolicy=","source":"k8s/k8s.go:118","time":"2023-06-12T14:59:11Z"}
{"level":"info","msg":"Patched hook(s)","source":"k8s/k8s.go:138","time":"2023-06-12T14:59:11Z"}
```

```
cray-sysmgmt-health-kube-p-admission-patch-qjkcb               0/1    Complete                                                                            d  0              9s
```