### PR TITLE
CASMPET-6651 cray-sysmgmt-health node affinity is wrong for mercury

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.1
+version: 0.28.2
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
@@ -47,21 +47,12 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchFields:
-              - key: metadata.name
-                operator: In
-                values:
-                - ncn-m001
-            - matchFields:
-              - key: metadata.name
-                operator: In
-                values:
-                - ncn-m002
-            - matchFields:
-              - key: metadata.name
-                operator: In
-                values:
-                - ncn-m003
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
## Summary and Scope

cray-sysmgmt-health grok-exporter node affinity is wrong for mercury. It is using ncn-m001, ncn-m002 and ncn-m003 by default. But mercury has no NCNs and it will fail.
_This change is a backward-compatible bugfix_

## Issues and Related PRs

* Resolves [CASMPET-6651](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6651)
* Change will also be needed in `<release/1.4>`

## Testing
### Tested on:

  * `<frigg>`
  * Local development environment
  * Virtual Shasta - Ashton
  * Mercury

### Test description:

_The changes tested and success verified._

```
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-9r7xn                1/1     Running                      0              3m20s   10.32.128.5     k8s-master-sigma7-3    <none>           <none>
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-grbq6                1/1     Running                      0              3m21s   10.32.64.4      k8s-master-sigma7-2    <none>           <none>
sysmgmt-health   cray-sysmgmt-health-grok-exporter-6dfd6c455b-z572c                1/1     Running                      0              3m20s   10.32.0.8       k8s-master-sigma7-1    <none>           <none>
```
```
kubectl get pods -n sysmgmt-health -o wide |grep grok
cray-sysmgmt-health-grok-exporter-6dfd6c455b-c4s67              1/1     Running     0              2m36s   10.38.0.2     ncn-m003   <none>           <none>
cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q              0/1     Pending     0              2m36s   <none>        <none>     <none>           <none>
cray-sysmgmt-health-grok-exporter-6dfd6c455b-wq7h8              1/1     Running     0              2m36s   10.32.0.3     ncn-m002   <none>           <none>
```
```
kubectl describe pod -n sysmgmt-health cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q
Name:           cray-sysmgmt-health-grok-exporter-6dfd6c455b-vnv5q
Namespace:      sysmgmt-health
Priority:       0
Node:           <none>
Labels:         app=grok-exporter
                pod-template-hash=6dfd6c455b
Annotations:    kubernetes.io/limit-ranger:
                  LimitRanger plugin set: cpu, memory request for container grok-exporter; cpu, memory limit for container grok-exporter
                kubernetes.io/psp: restricted-transition
Status:         Pending
IP:
IPs:            <none>
Controlled By:  ReplicaSet/cray-sysmgmt-health-grok-exporter-6dfd6c455b
Containers:
  grok-exporter:
    Image:      artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter:latest
    Port:       9144/TCP
    Host Port:  0/TCP
    Limits:
      cpu:     2
      memory:  2Gi
    Requests:
      cpu:        10m
      memory:     64Mi
    Environment:  <none>
    Mounts:
      /etc/grok_exporter from grok-config-volume (rw)
      /logs/goss_tests from logs (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-6zsv6 (ro)
Conditions:
  Type           Status
  PodScheduled   False
Volumes:
  grok-config-volume:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      cray-sysmgmt-health-grok-exporter
    Optional:  false
  logs:
    Type:          HostPath (bare host directory volume)
    Path:          /opt/cray/tests/install/logs/grok_exporter
    HostPathType:  DirectoryOrCreate
  kube-api-access-6zsv6:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node-role.kubernetes.io/master:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age    From                  Message
  ----     ------            ----   ----                  -------
  Warning  FailedScheduling  5m10s  default-scheduler     0/5 nodes are available: 2 node(s) didn't match pod anti-affinity rules, 3 node(s) didn't match Pod's node affinity/selector.
  Warning  FailedScheduling  4m11s  default-scheduler     0/5 nodes are available: 2 node(s) didn't match pod anti-affinity rules, 3 node(s) didn't match Pod's node affinity/selector.
  Warning  PolicyViolation   5m11s  admission-controller  Rule(s) 'host-path' of policy 'disallow-host-path' failed to apply on the resource
```


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
