### PR TITLE
CASMMON-327: cray-symgmt-health can fail on new installs

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.3
+version: 0.28.4
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/thanos/upload-secret.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/thanos/upload-secret.yaml
@@ -63,7 +63,7 @@ spec:
                   type: s3
                   config:
                     bucket: thanos
-                    endpoint: "rgw-vip.local"
+                    endpoint: "rgw-vip.nmn"
                     insecure: true
                     access_key: "$access_key"
                     secret_key: "$secret_key"


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

https://jira-pro.it.hpe.com:8443/browse/CASMMON-327

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-327

### Tested on:

  * Virtual Shasta - Fearne

### Test description:

pit:~ # kubectl get pods -n sysmgmt-health
NAME                                                            READY   STATUS      RESTARTS     AGE
alertmanager-cray-sysmgmt-health-kube-p-alertmanager-0          2/2     Running     1 (8h ago)   8h
cray-sysmgmt-health-canu-test-6688766dd9-672nt                  2/2     Running     0            8h
cray-sysmgmt-health-grafana-768766bb95-8xm7x                    3/3     Running     0            8h
cray-sysmgmt-health-grafterm-555dcffcd4-g67lz                   1/1     Running     0            8h
cray-sysmgmt-health-grok-exporter-6b64849ff5-9b2pj              1/1     Running     0            8h
cray-sysmgmt-health-grok-exporter-6b64849ff5-f96j9              0/1     Pending     0            8h
cray-sysmgmt-health-grok-exporter-6b64849ff5-npgsm              1/1     Running     0            8h
cray-sysmgmt-health-kube-p-operator-ffcbf9569-hqqdb             1/1     Running     0            8h
cray-sysmgmt-health-kube-state-metrics-9ccffd45f-2hw7b          1/1     Running     0            8h
cray-sysmgmt-health-node-exporter-smartmon-74qb6                1/1     Running     0            8h
cray-sysmgmt-health-node-exporter-smartmon-fqq94                1/1     Running     0            8h
cray-sysmgmt-health-node-exporter-smartmon-l2487                1/1     Running     0            8h
cray-sysmgmt-health-node-exporter-smartmon-m9pzg                1/1     Running     0            8h
cray-sysmgmt-health-node-exporter-smartmon-r2vzp                1/1     Running     0            8h
cray-sysmgmt-health-patch-nodeexporter-alerts-1-w85cc           0/1     Completed   0            8h
cray-sysmgmt-health-patch-nodeexporter-alerts-2-v7kth           0/1     Completed   0            146m
cray-sysmgmt-health-patch-service-monitors-2-qgrx6              0/1     Completed   0            147m
cray-sysmgmt-health-patch-thanos-secret-pxzjp                   0/1     Completed   0            147m
cray-sysmgmt-health-prometheus-node-exporter-dtmjv              1/1     Running     0            8h
cray-sysmgmt-health-prometheus-node-exporter-lpdks              1/1     Running     0            8h
cray-sysmgmt-health-prometheus-node-exporter-v62ct              1/1     Running     0            8h
cray-sysmgmt-health-prometheus-node-exporter-x8c46              1/1     Running     0            8h
cray-sysmgmt-health-prometheus-node-exporter-xghks              1/1     Running     0            8h
cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd-kvzwb   1/1     Running     0            8h
cray-sysmgmt-health-thanos-compactor-0                          1/1     Running     0            8h
cray-sysmgmt-health-thanos-query-0                              1/1     Running     0            8h
cray-sysmgmt-health-thanos-store-0                              1/1     Running     0            144m
prometheus-cray-sysmgmt-health-kube-p-prom-0                    3/3     Running     0            8h
prometheus-cray-sysmgmt-health-kube-p-prom-1                    3/3     Running     0            8h
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-0            3/3     Running     0            8h
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-1            3/3     Running     0            8h
thanos-ruler-kube-prometheus-stack-thanos-ruler-0               2/2     Running     0            8h





