### PR TITLE
CASMMON-334 Stop the flood of useless Apparmor messages for node-exporter pod - release/1.4

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.26.22
+version: 0.26.23
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -360,6 +360,8 @@ prometheus-operator:
       keyFile: "/etc/prometheus/secrets/etcd-client-cert/etcd-client-key"
 
   prometheus-node-exporter:
+    podAnnotations:
+      container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
 
     image:
       repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter


### PR DESCRIPTION
## Summary and Scope

_Impacted NCN-{M,W} console logs as they are filled with AppArmor errors. Critical bug fix._
_Backwards compatible bugfix._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMMON-334](https://jira-pro.it.hpe.com:8443/browse/CASMMON-334)
* [CAST-33453](https://jira-pro.it.hpe.com:8443/browse/CAST-33453)
* Change will also be needed in `<release1.4>`

## Testing

### Tested on:

  * `<hela>`
  * Local development environment
  * Virtual Shasta

### Test description:

_Tested successfully and no dmesg errors were seen or audit logs created after the changes._
- Upgrade tested.

Latest chart from PR -
```
ncn-m001:/mnt/developer/sum # helm list -A | grep cray-sys
cray-sysmgmt-health                     sysmgmt-health          1               2023-07-31 10:02:00.643470856 +0000 UTC deployed        cray-sysmgmt-health-0.26.23-20230731095541+ac4ae91      9.3.1
```
podAnnotations is seen -
```
ncn-m001:/mnt/developer/sum # kubectl describe pod -n sysmgmt-health cray-sysmgmt-health-prometheus-node-exporter-6tsvf
Name:         cray-sysmgmt-health-prometheus-node-exporter-6tsvf
Namespace:    sysmgmt-health
Priority:     0
Node:         ncn-m001/10.252.1.13
Start Time:   Mon, 31 Jul 2023 10:04:21 +0000
Labels:       app=prometheus-node-exporter
              chart=prometheus-node-exporter-1.10.0
              controller-revision-hash=796b7f9798
              heritage=Helm
              jobLabel=node-exporter
              pod-template-generation=2
              release=cray-sysmgmt-health
Annotations:  **container.apparmor.security.beta.kubernetes.io/node-exporter: unconfined**
              kubernetes.io/psp: cray-sysmgmt-health-prometheus-node-exporter
Status:       Running
```
No errors seen -
```
ncn-m001:/mnt/developer/sum # dmesg -T | tail -5
[Mon Jul 31 10:07:13 2023] IPVS: rr: TCP 10.30.204.69:443 - no destination available
[Mon Jul 31 10:09:56 2023] IPVS: rr: TCP 10.30.204.69:443 - no destination available
[Mon Jul 31 10:09:57 2023] IPVS: rr: TCP 10.30.204.69:443 - no destination available
[Mon Jul 31 10:09:57 2023] IPVS: rr: TCP 10.30.204.69:443 - no destination available
[Mon Jul 31 10:09:58 2023] IPVS: rr: TCP 10.30.204.69:443 - no destination available
```
No audit logs generated -
```
ncn-m001:/mnt/developer/sum # ls /var/log/audit
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable