### PR TITLE
create endpoint,service and service monitor to enabling UAN SMART data

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.8
+version: 0.28.9
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/endpoints.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/endpoints.yaml
@@ -1,0 +1,42 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{- if .Values.uanNodeExporter.enabled }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-uan-node-exporter
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-uan-node-exporter
+    release: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+subsets:
+  - addresses:
+      {{- range .Values.uanNodeExporter.endpoints }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      - name: http-metrics
+        port: {{ .Values.uanNodeExporter.service.port }}
+        protocol: TCP
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/service.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/service.yaml
@@ -1,0 +1,42 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{- if .Values.uanNodeExporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-uan-node-exporter
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-uan-node-exporter
+    release: {{ template "cray-sysmgmt-health.name" . }}
+    jobLabel: nodeExporter
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      protocol: TCP
+      port: {{ .Values.uanNodeExporter.service.port }}
+      targetPort: {{ .Values.uanNodeExporter.service.targetPort }}
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/servicemonitor.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/uan/nodeExporter/servicemonitor.yaml
@@ -1,0 +1,75 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+{{- if .Values.uanNodeExporter.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cray-sysmgmt-health.fullname" . }}-uan-node-exporter
+  labels:
+    app: {{ template "cray-sysmgmt-health.name" . }}-uan-node-exporter
+    release: {{ template "cray-sysmgmt-health.name" . }}
+{{ include "cray-sysmgmt-health.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cray-sysmgmt-health.name" . }}-uan-node-exporter
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http-metrics
+    {{- if .Values.uanNodeExporter.serviceMonitor.interval }}
+    interval: {{ .Values.uanNodeExporter.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.uanNodeExporter.serviceMonitor.honor_labels }}
+    honorLabels: {{ .Values.uanNodeExporter.serviceMonitor.honor_labels }}
+    {{- end }}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- if eq .Values.uanNodeExporter.serviceMonitor.scheme "https" }}
+    scheme: https
+    tlsConfig:
+      {{- if .Values.uanNodeExporter.serviceMonitor.serverName }}
+      serverName: {{ .Values.uanNodeExporter.serviceMonitor.serverName }}
+      {{- end }}
+      {{- if .Values.uanNodeExporter.serviceMonitor.caFile }}
+      caFile: {{ .Values.uanNodeExporter.serviceMonitor.caFile }}
+      {{- end }}
+      {{- if  .Values.uanNodeExporter.serviceMonitor.certFile }}
+      certFile: {{ .Values.uanNodeExporter.serviceMonitor.certFile }}
+      {{- end }}
+      {{- if .Values.uanNodeExporter.serviceMonitor.keyFile }}
+      keyFile: {{ .Values.uanNodeExporter.serviceMonitor.keyFile }}
+      {{- end}}
+      insecureSkipVerify: {{ .Values.uanNodeExporter.serviceMonitor.insecureSkipVerify }}
+    {{- end }}
+{{- if .Values.uanNodeExporter.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.uanNodeExporter.serviceMonitor.metricRelabelings | indent 4) . }}
+{{- end }}
+{{- if .Values.uanNodeExporter.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.uanNodeExporter.serviceMonitor.relabelings | indent 4 }}
+{{- end }}
+{{- end }}

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -707,6 +707,24 @@ cephExporter:
     metricsRelabelings: {}
     relabelings: {}
 
+uanNodeExporter:
+  enabled: false
+  endpoints: []
+  service:
+    port: 9100
+    targetPort: 9100
+  serviceMonitor:
+    interval: 30s
+    scheme: http
+    # honor_labels: false
+    # serverName: ""
+    # caFile: ""
+    # certFile: ""
+    # keyFile: ""
+    insecureSkipVerify: false
+    metricsRelabelings: {}
+    relabelings: {}
+
 cephNodeExporter:
   enabled: true
   endpoints: []


### PR DESCRIPTION
## Summary and Scope
create endpoint,service and service monitor to enabling SMART data on UAN

## Issues and Related PRs
[
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._](

https://jira-pro.it.hpe.com:8443/browse/CASMMON-340
tested on shandy
custmization.yaml changes under cray-sysmgmt-health chart
      uanNodeExporter:
        enabled: true
        endpoints:
        - 10.252.1.23


![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/22464568/736551ab-287a-4f65-ad36-3c72f5e17988)

![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/22464568/5bffede9-05e2-42e0-9251-9e4d87b96e64)



ncn-m001:/mnt/developer/ram # curl http://10.252.1.23:9100/metrics |more
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which node_exporter was built.
# TYPE node_exporter_build_info gauge
100 20117    0 20117    0  node_exporter_build_info{branch="HEAD",goversion="go1.19.3",revision="1b48970ffcf5630534fb00bb0687d73c66d1c959",version="1.5.0"} 1
   0  9822k      0 --:--:-- --:-# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
-:-- --:--:-- 982# TYPE node_scrape_collector_duration_seconds gauge
2k
node_scrape_collector_duration_seconds{collector="textfile"} 0.001161701
# HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
# TYPE node_scrape_collector_success gauge
node_scrape_collector_success{collector="textfile"} 1
# HELP node_textfile_mtime_seconds Unixtime mtime of textfiles successfully read.
# TYPE node_textfile_mtime_seconds gauge
node_textfile_mtime_seconds{file="/var/lib/node_exporter/smartmon.prom"} 1.694069332e+09
# HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
# TYPE node_textfile_scrape_error gauge
node_textfile_scrape_error 0
# HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
# TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
# HELP smartmon_airflow_temperature_cel_raw_value SMART metric airflow_temperature_cel_raw_value
# TYPE smartmon_airflow_temperature_cel_raw_value gauge
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sda",smart_id="190",type="sat"} 24
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdb",smart_id="190",type="sat"} 24
# HELP smartmon_airflow_temperature_cel_threshold SMART metric airflow_temperature_cel_threshold
# TYPE smartmon_airflow_temperature_cel_threshold gauge
smartmon_airflow_temperature_cel_threshold{disk="/dev/sda",smart_id="190",type="sat"} 0
smartmon_airflow_temperature_cel_threshold{disk="/dev/sdb",smart_id="190",type="sat"} 0
# HELP smartmon_airflow_temperature_cel_value SMART metric airflow_temperature_cel_value
# TYPE smartmon_airflow_temperature_cel_value gauge
smartmon_airflow_temperature_cel_value{disk="/dev/sda",smart_id="190",type="sat"} 76
smartmon_airflow_temperature_cel_value{disk="/dev/sdb",smart_id="190",type="sat"} 76
# HELP smartmon_airflow_temperature_cel_worst SMART metric airflow_temperature_cel_worst
# TYPE smartmon_airflow_temperature_cel_worst gauge
smartmon_airflow_temperature_cel_worst{disk="/dev/sda",smart_id="190",type="sat"} 66
smartmon_airflow_temperature_cel_worst{disk="/dev/sdb",smart_id="190",type="sat"} 63
# HELP smartmon_current_pending_sector_raw_value SMART metric current_pending_sector_raw_value
# TYPE smartmon_current_pending_sector_raw_value gauge
smartmon_current_pending_sector_raw_value{disk="/dev/sda",smart_id="197",type="sat"} 0
smartmon_current_pending_sector_raw_value{disk="/dev/sdb",smart_id="197",type="sat"} 0
# HELP smartmon_current_pending_sector_threshold SMART metric current_pending_sector_threshold
# TYPE smartmon_current_pending_sector_threshold gauge
smartmon_current_pending_sector_threshold{disk="/dev/sda",smart_id="197",type="sat"} 0
smartmon_current_


