### PR TITLE
Fix thanos-ruler-kube-prometheus-stack-thanos-ruler pod disruption budget

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.9
+version: 0.28.10
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -333,7 +333,7 @@ kube-prometheus-stack:
       name: ""
       annotations: {}
     podDisruptionBudget:
-      enabled: true
+      enabled: false
       minAvailable: 1
       maxUnavailable: ""
     service:


### PR DESCRIPTION
## Summary and Scope

Fix thanos-ruler-kube-prometheus-stack-thanos-ruler pod disruption budget.
This regarding the pod disruption budget for thanos-ruler-kube-prometheus-stack-thanos-ruler .    We see that this statefulset is defined as a singleton but the pod disruption budget doesn't allow that singleton pod to be removed when a node is drained.    Kubernetes guidelines say that singleton pods should tolerate downtime and not have a pod disruption budget. 
  
## Issues and Related PRs
[CASMMON-342](https://jira-pro.it.hpe.com:8443/browse/CASMMON-342)

## Testing

_List the environments in which these changes were tested._

### Tested on: Mug
before the fix

 kubectl -n sysmgmt-health get pdb
NAME                                 MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
kube-prometheus-stack-thanos-ruler   1               N/A               0                     84d

After fix

 kubectl -n sysmgmt-health get pdb
No resources found in sysmgmt-health namespace.



