### PR TITLE
CASMMON-345-and-346(release 1.5 and 1.6)

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.11
+version: 0.28.12
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/smartmon/smartmon.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/smartmon/smartmon.json
@@ -1,41 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.3.2"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -63,7 +26,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 3992,
   "graphTooltip": 0,
-  "id": null,
+  "id": 69,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -148,7 +111,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "smartmon_device_smart_healthy{instance=~\"$instance\"} < 1",
+          "expr": "smartmon_device_smart_healthy{instance=~\"$host:$port\"} < 1",
           "format": "table",
           "interval": "",
           "intervalFactor": 2,
@@ -259,12 +222,14 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(smartmon_airflow_temperature_cel_value{instance=~\"$instance\"}) by (instance, disk)",
+          "editorMode": "code",
+          "expr": "avg(smartmon_airflow_temperature_cel_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "val {{instance}} {{disk}}",
+          "range": true,
           "refId": "B"
         },
         {
@@ -272,12 +237,14 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(smartmon_airflow_temperature_cel_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "editorMode": "code",
+          "expr": "avg(smartmon_airflow_temperature_cel_raw_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
           "intervalFactor": 2,
           "legendFormat": "raw {{instance}} {{disk}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -376,7 +343,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(smartmon_total_lbas_read_value{instance=~\"$instance\"}) by (instance, disk)",
+          "expr": "avg(smartmon_total_lbas_read_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "val {{instance}} {{disk}}",
@@ -388,11 +355,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(smartmon_spin_retry_count_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "editorMode": "code",
+          "expr": "avg(smartmon_spin_retry_count_raw_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "raw {{instance}} {{disk}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -491,7 +460,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(smartmon_total_lbas_written_value{instance=~\"$instance\"}) by (instance, disk)",
+          "expr": "avg(smartmon_total_lbas_written_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "val {{instance}} {{disk}}",
@@ -503,10 +472,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "avg(smartmon_total_lbas_written_raw_value{instance=~\"$instance\"}) by (instance, disk)",
+          "editorMode": "code",
+          "expr": "avg(smartmon_total_lbas_written_raw_value{instance=~\"$host:$port\"}) by (instance, disk)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "raw {{instance}} {{disk}}",
+          "range": true,
           "refId": "B"
         }
       ],
@@ -605,10 +576,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "smartmon_reallocated_sector_ct_raw_value{instance=~\"$instance\"}",
+          "editorMode": "code",
+          "expr": "smartmon_reallocated_sector_ct_raw_value{instance=~\"$host:$port\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "raw {{instance}} {{disk}}",
+          "range": true,
           "refId": "B"
         },
         {
@@ -616,11 +589,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "smartmon_reallocated_sector_ct_value{instance=~\"$instance\"}",
+          "editorMode": "code",
+          "expr": "smartmon_reallocated_sector_ct_value{instance=~\"$host:$port\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "val {{instance}} {{disk}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -719,10 +694,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "smartmon_current_pending_sector_raw_value{instance=~\"$instance\"}",
+          "editorMode": "code",
+          "expr": "smartmon_current_pending_sector_raw_value{instance=~\"$host:$port\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "raw {{instance}} {{disk}}",
+          "range": true,
           "refId": "B"
         },
         {
@@ -730,11 +707,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "smartmon_current_pending_sector_value{instance=~\"$instance\"}",
+          "editorMode": "code",
+          "expr": "smartmon_current_pending_sector_value{instance=~\"$host:$port\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "val {{instance}} {{disk}}",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -744,16 +723,12 @@
   ],
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [
-    "prometheus",
-    "node_exporter",
-    "smartmon"
-  ],
+  "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "default",
           "value": "default"
         },
@@ -771,29 +746,86 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "ncn-s003",
+          "value": "ncn-s003"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "",
+        "definition": "label_values(nodename)",
+        "description": "label_values(nodename)",
         "hide": 0,
-        "includeAll": true,
-        "multi": true,
-        "name": "instance",
+        "includeAll": false,
+        "label": "node",
+        "multi": false,
+        "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(smartmon_smartctl_version, instance)",
-          "refId": "Prometheus-instance-Variable-Query"
+          "query": "label_values(nodename)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "9100",
+          "value": "9100"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(smartmon_smartctl_version, instance)",
+        "hide": 2,
+        "includeAll": false,
+        "label": "port",
+        "multi": false,
+        "name": "port",
+        "options": [],
+        "query": {
+          "query": "label_values(smartmon_smartctl_version, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/[^:]+:(.*)/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "10.252.1.12",
+          "value": "10.252.1.12"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(node_uname_info{nodename=\"$node\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values(node_uname_info{nodename=\"$node\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/([^:]+):.*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
@@ -827,7 +859,7 @@
   },
   "timezone": "browser",
   "title": "SMARTMON",
-  "uid": "CGWTF6F7k",
-  "version": 1,
+  "uid": "v7gfc1MSk",
+  "version": 10,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/timescaledb/timescaledb.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/timescaledb/timescaledb.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 69,
+  "id": 70,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2938,7 +2938,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "thanos",
           "value": "thanos"
         },
@@ -3085,9 +3085,9 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "gitea-vcs-postgres-1",
-          "value": "gitea-vcs-postgres-1"
+          "selected": true,
+          "text": "spire-postgres-1",
+          "value": "spire-postgres-1"
         },
         "datasource": {
           "type": "prometheus",
@@ -3095,8 +3095,8 @@
         },
         "definition": "label_values(pg_up, pod)",
         "hide": 0,
-        "includeAll": false,
-        "label": "Cluster",
+        "includeAll": true,
+        "label": "Pod",
         "multi": false,
         "name": "Cluster",
         "options": [],
@@ -3143,7 +3143,7 @@
   },
   "timezone": "",
   "title": "TimescaleDB",
-  "uid": "5r5TNiMSz",
-  "version": 4,
+  "uid": "c-BNy3MSk",
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

CASMMON-345: CSM 1.5: Grafana dashboard for smartmon , instances name is not listing instead ip is listing
CASMMON-346: CSM 1.5: Grafan TimescaleDB dashboard ALL option is not available for list of postgres pods
CASMMON-347: CSM 1.5: Grafan TimescaleDB dashboard variable name is mentioned as cluster instead of pod

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves: 
* CASMMON-345: https://jira-pro.it.hpe.com:8443/browse/CASMMON-345
* CASMMON-346: https://jira-pro.it.hpe.com:8443/browse/CASMMON-346
* CASMMON-347: https://jira-pro.it.hpe.com:8443/browse/CASMMON-347

## Testing

_List the environments in which these changes were tested._

### Tested on:
Starlord

Smartmon Dashboard:

<img width="960" alt="grafana_smartmon_starlord_0" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/f2b77315-7bc1-41b7-932a-386285270d95">

<img width="959" alt="grafana_smartmon_starlord_1" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/14310102-59f1-4443-8b67-b44f5f5ba4f6">

TimescaleDB dashboard:

<img width="964" alt="grafana_timescaledb_starlord_0" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/7bf047fc-68b2-47fc-8591-b8a2472bd473">

<img width="959" alt="grafana_timescaledb_starlord_1" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/b423b8c5-5305-47d6-93a3-d5217521eb43">

<img width="960" alt="grafana_timescaledb_starlord_2" src="https://github.com/Cray-HPE/cray-sysmgmt-health/assets/59766437/45f5a8f6-f68f-47ab-baa2-85155c09d600">

