### PR TITLE
New Thanos Service is configured without storage limits

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.29.0
+version: 0.29.1
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -52,9 +52,9 @@ thanosSecret:
         api_version: v1
 
 thanosCompactor:
-  resolutionraw: 0d
-  resolution5m: 0d
-  resolution1h: 0d
+  resolutionraw: 15d
+  resolution5m: 15d
+  resolution1h: 15d
   resources:
     limits:
       memory: 4Gi


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-369

## Testing

_List the environments in which these changes were tested._

### Tested on:

Slice

### Test description:

```
ncn-m001:/mnt/admin/dmb/ceph # ceph df
--- RAW STORAGE ---
CLASS    SIZE   AVAIL    USED  RAW USED  %RAW USED
ssd    31 TiB  21 TiB  10 TiB    10 TiB      33.01
TOTAL  31 TiB  21 TiB  10 TiB    10 TiB      33.01

--- POOLS ---
POOL                        ID  PGS   STORED  OBJECTS     USED  %USED  MAX AVAIL
.mgr                         1    1  164 MiB       42  493 MiB      0    5.6 TiB
cephfs.cephfs.meta           2   64  332 MiB   31.02k  997 MiB      0    5.6 TiB
cephfs.cephfs.data           3  128  414 GiB  297.21k  1.2 TiB   6.77    5.6 TiB
.rgw.root                    4   32  1.3 KiB        4   48 KiB      0    5.6 TiB
default.rgw.log              5   32  380 KiB      209  1.8 MiB      0    5.6 TiB
default.rgw.control          6   32      0 B        8      0 B      0    5.6 TiB
default.rgw.meta             7   32   34 KiB      181  1.6 MiB      0    5.6 TiB
cephfs.admin-tools.meta      8   16  276 MiB   21.32k  829 MiB      0    5.6 TiB
cephfs.admin-tools.data      9   32  523 GiB  287.87k  1.5 TiB   8.40    5.6 TiB
default.rgw.buckets.index   10   32   19 MiB      220   58 MiB      0    5.6 TiB
kube                        11   64  1.3 TiB  780.27k  2.8 TiB  14.22    5.6 TiB
smf                         12   64  244 GiB  809.46k  168 GiB   0.97    8.4 TiB
zone1.rgw.buckets.data      13   32      0 B        0      0 B      0    5.6 TiB
default.rgw.buckets.data    14   32  1.6 TiB  450.73k  4.7 TiB  21.79    5.6 TiB
default.rgw.buckets.non-ec  15   32  149 KiB        1  460 KiB      0    5.6 TiB
```

====================================================

ncn-m001:/mnt/admin/dmb/ceph # ./check_buckets
Bucket                    | Count    |      Usage
------------------------- | -------- | ----------
admin-tools               |        0 |    0.00 GB
badger                    |        0 |    0.00 GB
boot-images               |      660 |  921.98 GB
config-data               |    28919 |    1.34 GB
etcd-backup               |      479 |   67.44 GB
fw-update                 |       40 |    1.99 GB
ims                       |       67 |    0.00 GB
install-artifacts         |        0 |    0.00 GB
nmd                       |       25 |   43.87 GB
postgres-backup           |       24 |    0.00 GB
sat                       |        2 |    0.00 GB
sds                       |     5307 |    5.55 GB
sls                       |        2 |    0.00 GB
sma                       |       46 |    0.00 GB
ssd                       |        0 |    0.00 GB
ssm                       |        0 |    0.00 GB
thanos                    |     1373 |  520.85 GB
user                      |        0 |    0.00 GB
velero                    |     7538 |   19.63 GB
wlm                       |       13 |    0.06 GB



