### PR TITLE
Retrieve SMART metrics from E1000 via redfish and send via Prometheus

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -37,6 +37,8 @@ jobs:
       ct-config: |
         chart-dirs:
           - kubernetes
+        chart-repos:
+          - csm-algol60=https://artifactory.algol60.net/artifactory/csm-helm-charts
         validate-maintainers: false
       scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
       scan-images: false

--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.28.14
+version: 0.28.17
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:
@@ -47,6 +47,9 @@ dependencies:
 - name: prometheus-snmp-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.1.0
+- name: redfish-exporter
+  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  version: 0.0.2
 maintainers:
 - name: bklein
 - name: brantk-hpe

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -115,6 +115,13 @@ prometheus-snmp-exporter:
       - name: sw-spine-02
         target: 10.254.0.3
 
+redfish-exporter:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/redfish-exporter
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 0.0.2
+
 kube-prometheus-stack:
 
   thanos:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-364

## Testing

### Tested on:

Odin (CSM-1.5)
ClusterStor E1000 - kjlmo900.hpc.amslabs.hpecorp.net

### Test description:

```
ncn-w003:/var/lib/node_exporter # ls
fetch_health.sh  redfish-smart-1.prom  redfish-smart-2.prom  smartmon.prom
ncn-w003:/var/lib/node_exporter # cat redfish-smart-2.prom
#HELP redfish_up Redfish Server Monitoring availability
#TYPE redfish_up gauge
redfish_up{host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220"} 1.0
#HELP redfish_response_duration_seconds Redfish Server Monitoring response time
#TYPE redfish_response_duration_seconds gauge
redfish_response_duration_seconds{host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220"} 0.13
#HELP redfish_health Redfish Server Monitoring Health Data
#TYPE redfish_health gauge
redfish_health{device_name="summary",device_type="system",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220"} 0.0
smartmon_device_active{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sde",model_family="st16000nm002g",serial_number="ZL21TFEY0000C016KSVD",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 33.0
smartmon_power_cycle_count_raw_value{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 30510.0
smartmon_smartctl_run{disk="/dev/sde",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076004e+09
smartmon_device_active{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdj",model_family="st16000nm002g",serial_number="ZL21YA660000C016MQRB",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 33.0
smartmon_power_cycle_count_raw_value{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 30510.0
smartmon_smartctl_run{disk="/dev/sdj",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076005e+09
smartmon_device_active{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdk",model_family="st16000nm002g",serial_number="ZL22EECC0000C016KP3H",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 33.0
smartmon_power_cycle_count_raw_value{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 30531.0
smartmon_smartctl_run{disk="/dev/sdk",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076005e+09
smartmon_device_active{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdm",model_family="st16000nm002g",serial_number="ZL21SX3S0000C015C1FN",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 33.0
smartmon_power_cycle_count_raw_value{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 30363.0
smartmon_smartctl_run{disk="/dev/sdm",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076006e+09
smartmon_device_active{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdo",model_family="st16000nm002g",serial_number="ZL21F5HS0000C0043M6C",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 32.0
smartmon_power_cycle_count_raw_value{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 31569.0
smartmon_smartctl_run{disk="/dev/sdo",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076006e+09
smartmon_device_active{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sds",model_family="st16000nm002g",serial_number="ZL21FEFF0000C004GUTF",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 31.0
smartmon_power_cycle_count_raw_value{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 31565.0
smartmon_smartctl_run{disk="/dev/sds",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076007e+09
smartmon_device_active{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdv",model_family="st16000nm002g",serial_number="ZL20JXW20000C0032KDR",type="sas"} 1.0
smartmon_temperature_celsius_raw_value{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 29.0
smartmon_power_cycle_count_raw_value{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 0.0
smartmon_power_on_hours_raw_value{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 30503.0
smartmon_smartctl_run{disk="/dev/sdv",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.715076007e+09
smartmon_device_active{disk="/dev/sdx",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_available{disk="/dev/sdx",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_enabled{disk="/dev/sdx",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_smart_healthy{disk="/dev/sdx",host="kjlmo900.hpc.amslabs.hpecorp.net",redfish_instance="10.214.132.198:9220",type="sas"} 1.0
smartmon_device_info{disk="/dev/sdx",model_family="st16000nm002g",serial_number="ZL2AK81E0000C1127CBM",type="sas"} 1.0

```
![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/53111642/84e6805b-9c57-4f60-903b-13b333cb5bbe)




