### PR TITLE
Grafana Sealed Secrets

### DIFF
--- a/kubernetes/cray-sysmgmt-health/templates/grafana/sealed-secrets.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grafana/sealed-secrets.yaml
@@ -1,0 +1,33 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+{{- if .Values.sealedSecrets -}}
+{{- range $val := .Values.sealedSecrets }}
+{{- if $val.kind }}
+{{- if eq $val.kind "SealedSecret" }}
+---
+{{ toYaml $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary and Scope

Add template file to render sealed secrets passed via customizations.yaml.

This is required to be able to use store sensitive values - define grafana admin user and password.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible.
