### PR TITLE
CASMPET-7085 update chart with node-role.kubernetes.io/control-plane changes for k8s 1.24

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.29.4
+version: 0.30.0
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/grok-exporter/deployment.yaml
@@ -50,9 +50,6 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -86,4 +83,7 @@ spec:
       tolerations:
         - effect: "NoSchedule"
           key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: "NoSchedule"
+          key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/node_exporter-smartmon/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoSchedule"
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       terminationGracePeriodSeconds: 5

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -92,7 +92,7 @@ grokExporter:
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 thanos:


### PR DESCRIPTION
## Summary and Scope

Update sysmgmt-health with "node-role.kubernetes.io/control-plane" changes for k8s 1.24. Additionally, have charts use docker image docker-kubectl version 1.24.17 for k8s 1.24. This is a necessary change for CSM 1.6.

## Issues and Related PRs

* Resolves [CASMPET-7085](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7085)

## Testing

Upgraded chart on Beau to this chart. Everything upgraded successfully.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

