### PR TITLE
CSM build issue fix

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.30.1
+version: 0.30.2
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/_helpers.tpl
+++ b/kubernetes/cray-sysmgmt-health/templates/_helpers.tpl
@@ -90,7 +90,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "cray-sysmgmt-health.prometheus-snmp-exporter.selectorLabels" }}
-app.kubernetes.io/name: {{ include "cray-sysmgmt-health.prometheus-snmp-exporter.fullname" . }}
+app.kubernetes.io/name: prometheus-snmp-exporter
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -144,7 +144,7 @@ victoria-metrics-k8s-stack:
       replicationFactor: 2
       vmstorage:
         image:
-          repository: victoriametrics/vmstorage
+          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmstorage
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -163,7 +163,7 @@ victoria-metrics-k8s-stack:
 
       vmselect:
         image:
-          repository: victoriametrics/vmselect
+          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmselect
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -182,7 +182,7 @@ victoria-metrics-k8s-stack:
 
       vminsert:
         image:
-          repository: victoriametrics/vminsert
+          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vminsert
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -197,7 +197,7 @@ victoria-metrics-k8s-stack:
     enabled: true
     spec:
       image:
-        repository: victoriametrics/vmalert
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmalert
         tag: v1.93.1
 
   vmagent:
@@ -205,7 +205,7 @@ victoria-metrics-k8s-stack:
     spec:
       selectAllByDefault: true
       image:
-        repository: victoriametrics/vmagent
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmagent
         tag: v1.93.1
       secrets:
         - etcd-client-cert

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -144,7 +144,7 @@ victoria-metrics-k8s-stack:
       replicationFactor: 2
       vmstorage:
         image:
-          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmstorage
+          repository: victoriametrics/vmstorage
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -163,7 +163,7 @@ victoria-metrics-k8s-stack:
 
       vmselect:
         image:
-          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmselect
+          repository: victoriametrics/vmselect
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -182,7 +182,7 @@ victoria-metrics-k8s-stack:
 
       vminsert:
         image:
-          repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vminsert
+          repository: victoriametrics/vminsert
           tag: v1.93.1-cluster
         replicaCount: 2
         resources:
@@ -197,7 +197,7 @@ victoria-metrics-k8s-stack:
     enabled: true
     spec:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmalert
+        repository: victoriametrics/vmalert
         tag: v1.93.1
 
   vmagent:
@@ -205,7 +205,7 @@ victoria-metrics-k8s-stack:
     spec:
       selectAllByDefault: true
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmagent
+        repository: victoriametrics/vmagent
         tag: v1.93.1
       secrets:
         - etcd-client-cert

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -122,9 +122,9 @@ victoria-metrics-k8s-stack:
       pullPolicy: IfNotPresent
     env:
       - name: VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE
-        value: arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/docker.io/prom/prometheus-config-reloader:v0.62.0
+        value: artifactory.algol60.net/csm-docker/stable/docker.io/prom/prometheus-config-reloader:v0.62.0
       - name: VM_VMALERTDEFAULT_CONFIGRELOADIMAGE
-        value: arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
+        value: artifactory.algol60.net/csm-docker/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
   # -- Tells helm to remove CRD after chart remove
     cleanupCRD: true
     cleanupImage:
@@ -302,7 +302,7 @@ victoria-metrics-k8s-stack:
         tag: v0.25.0
       containers:
       - name: config-reloader
-        image: arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
+        image: artifactory.algol60.net/csm-docker/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
       retention: 48h
       logLevel: debug
       replicaCount: 2
@@ -415,8 +415,8 @@ victoria-metrics-k8s-stack:
           isDefault: true
 
     testFramework:
-      image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/bats/bats
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bats/bats
+      tag: v1.4.1
 
   # Exporters
   kubelet:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Resolved CSM build failure due to few image issues.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - https://jira-pro.it.hpe.com:8443/browse/CASMMON-401

## Testing

_List the environments in which these changes were tested._

### Tested on:

Fanta

### Test description:

![image](https://github.com/Cray-HPE/cray-sysmgmt-health/assets/53111642/eeddf78b-7e86-4f4a-8843-cd3feaabb352)

```
ncn-m001:/mnt/developer/shreni # kubectl get pods -n sysmgmt-health
NAME                                                             READY   STATUS    RESTARTS   AGE
cray-sysmgmt-health-canu-test-7c7468b479-t78lg                   2/2     Running   0          6m38s
cray-sysmgmt-health-grafana-5779c76594-lx6sk                     3/3     Running   0          6m38s
cray-sysmgmt-health-grok-exporter-7ff586bbb4-9bp8x               1/1     Running   0          6m38s
cray-sysmgmt-health-grok-exporter-7ff586bbb4-kzkfr               1/1     Running   0          6m38s
cray-sysmgmt-health-grok-exporter-7ff586bbb4-vj7cp               1/1     Running   0          6m38s
cray-sysmgmt-health-kube-state-metrics-bdcc6cb59-652fb           1/1     Running   0          6m38s
cray-sysmgmt-health-logstash-exporter-8455fffd5c-fnj8k           1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-224z5                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-5shwg                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-6zqdk                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-7ml9j                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-bpgbq                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-dw6kn                 1/1     Running   0          6m38s
cray-sysmgmt-health-node-exporter-smartmon-hkp4m                 1/1     Running   0          6m38s
cray-sysmgmt-health-prometheus-node-exporter-2skbn               1/1     Running   0          6m17s
cray-sysmgmt-health-prometheus-node-exporter-4w7m9               1/1     Running   0          6m10s
cray-sysmgmt-health-prometheus-node-exporter-6jdhs               1/1     Running   0          6m4s
cray-sysmgmt-health-prometheus-node-exporter-7jkq9               1/1     Running   0          6m14s
cray-sysmgmt-health-prometheus-node-exporter-dzqs8               1/1     Running   0          5m46s
cray-sysmgmt-health-prometheus-node-exporter-t8qnr               1/1     Running   0          6m7s
cray-sysmgmt-health-prometheus-node-exporter-tqtrh               1/1     Running   0          6m
cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd-xd2jj    1/1     Running   0          6m38s
cray-sysmgmt-health-victoria-metrics-operator-7478d786f8-c4mpt   1/1     Running   0          6m38s
vmagent-vms-0-759cdbc9cf-hzfwd                                   2/2     Running   0          6m4s
vmagent-vms-0-759cdbc9cf-zddx4                                   2/2     Running   0          6m4s
vmagent-vms-1-7475678b97-2k2mz                                   2/2     Running   0          6m3s
vmagent-vms-1-7475678b97-4h9xr                                   2/2     Running   0          6m4s
vmalert-vms-844978cf47-6jvk6                                     2/2     Running   0          6m4s
vmalertmanager-vms-0                                             2/2     Running   0          6m4s
vmalertmanager-vms-1                                             2/2     Running   0          6m4s
vminsert-vms-97cb76c98-m4gqw                                     1/1     Running   0          6m4s
vminsert-vms-97cb76c98-pwkmz                                     1/1     Running   0          6m4s
vmselect-vms-0                                                   1/1     Running   0          6m4s
vmselect-vms-1                                                   1/1     Running   0          6m4s
vmstorage-vms-0                                                  1/1     Running   0          6m4s
vmstorage-vms-1                                                  1/1     Running   0          6m4s
```
