### PR TITLE
CASMMON-415 Conversion to victoria-metrics broke spire chart upgrade

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 0.30.2
+version: 1.0.0
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb-controller.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb-controller.yaml
@@ -1,0 +1,21 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cray-metallb
+  name: metallb-controller
+  namespace: sysmgmt-health
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - metallb-system
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: cray-metallb
+      app.kubernetes.io/name: metallb

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb-speaker.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb-speaker.yaml
@@ -1,0 +1,21 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  labels:
+    app.kubernetes.io/component: speaker
+    app.kubernetes.io/instance: cray-metallb
+  name: metallb-speaker
+  namespace: sysmgmt-health
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - metallb-system
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: speaker
+      app.kubernetes.io/instance: cray-metallb
+      app.kubernetes.io/name: metallb

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/metallb.yaml
@@ -1,0 +1,68 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  labels:
+    app.kubernetes.io/instance: cray-metallb
+    app.kubernetes.io/name: metallb
+  name: metallb
+  namespace: metallb-system
+spec:
+  groups:
+  - name: metallb.rules
+    rules:
+    - alert: MetalLBStaleConfig
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has a stale config for > 1 minute'
+      expr: metallb_k8s_client_config_stale_bool{job="metallb"} == 1
+      for: 1m
+      labels:
+        severity: warning
+    - alert: MetalLBConfigNotLoaded
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has not loaded for > 1 minute'
+      expr: metallb_k8s_client_config_loaded_bool{job="metallb"} == 0
+      for: 1m
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolExhausted
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has exhausted address pool "{{`{{ $labels.pool }}`}}" for > 1 minute'
+      expr: metallb_allocator_addresses_in_use_total >= on(pool) metallb_allocator_addresses_total
+      for: 1m
+      labels:
+        severity: alert
+    - alert: MetalLBAddressPoolUsage75Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 75% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 75
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolUsage85Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 85% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 85
+      labels:
+        severity: warning
+    - alert: MetalLBAddressPoolUsage95Percent
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has address pool "{{`{{ $labels.pool }}`}}" past 95% usage for > 1 minute'
+      expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total
+        ) * 100 > 95
+      labels:
+        severity: alert
+    - alert: MetalLBBGPSessionDown
+      annotations:
+        message: '"{{`{{ $labels.job }}`}}" - MetalLB "{{`{{ $labels.container }}`}}" on "{{`{{ $labels.pod
+          }}`}}" has BGP session "{{`{{ $labels.peer }}`}}" down for > 1 minute'
+      expr: metallb_bgp_session_up{job="metallb"} == 0
+      for: 1m
+      labels:
+        severity: alert

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -1075,7 +1075,62 @@ servicemonitors:
       scheme: http
       metricsRelabelings: {}
       relabelings: {}
-
+  dnsUnbound:
+    enabled: true
+    servicename: cray-dns-unbound
+    serviceMonitor:
+      namespace: sysmgmt-health
+      port: exporter
+      matchNamespace:
+      - services
+      matchLabels:
+        service: cray-dns-unbound-dns-unbound-exporter
+      interval: 1m
+      scheme: http
+      metricsRelabelings: {}
+      relabelings: {}
+  powerDns:
+    enabled: true
+    servicename: powerdns
+    serviceMonitor:
+      namespace: sysmgmt-health
+      port: dns-api
+      matchNamespace:
+      - services
+      matchLabels:
+        service: cray-dns-powerdns-api
+      interval: 1m
+      scheme: http
+      metricsRelabelings: {}
+      relabelings: {}
+  cray-spire:
+    enabled: true
+    servicename: cray-spire
+    serviceMonitor:
+      namespace: sysmgmt-health
+      port: metrics
+      matchNamespace:
+      - cray-spire
+      matchLabels:
+        app.kubernetes.io/name: cray-spire-server
+      interval: 1m
+      scheme: http
+      metricsRelabelings: {}
+      relabelings: {}
+  spire:
+    enabled: true
+    servicename: spire
+    serviceMonitor:
+      namespace: sysmgmt-health
+      port: metrics
+      matchNamespace:
+      - spire
+      matchLabels:
+        app.kubernetes.io/name: spire-server
+      interval: 1m
+      scheme: http
+      metricsRelabelings: {}
+      relabelings: {}
   iufExporter:
     enabled: true
     servicename: argo-only-argo-workflows-workflow-controller


### PR DESCRIPTION
## Summary and Scope
Conversion to victoria-metrics broke spire chart upgrade.
 these VMScrape and other VM specific CRDs should be consolidated into a single chart rather than scattered liberally across unbound, kea, metallb, spire etc. So moving to cray-sysmgmt-health chart
## Issues and Related PRs

[_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`](https://jira-pro.it.hpe.com:8443/browse/CASMMON-415)

## Testing

_List the environments in which these changes were tested._

### Tested on: fanta

![image](https://github.com/user-attachments/assets/61e9f746-0e90-4beb-92fd-aafa9ae1b2ee)

![image](https://github.com/user-attachments/assets/6870e37b-3ead-421b-a5fd-c15969e46dc6)

![image](https://github.com/user-attachments/assets/2e20c051-99e7-4017-b122-8849f14566f1)

![image](https://github.com/user-attachments/assets/b1bc85b2-e799-411a-94c1-e817eadfcb5b)
