### PR TITLE
CASMPET-6820 daemonset pod to export iscsi metrics

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.0
+version: 1.0.1
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -19,7 +19,11 @@ spec:
       containers:
       - name: iscsi-container
         image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
+        {{-if .Values.iscsimetrics.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.iscsimetrics.image.pullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end -}}
         resources:
           limits:
             memory: 200Mi 

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ include "cray-sysmgmt-health.fullname" . }}-node-exporter-iscsi"
+  labels:
+    app.kubernetes.io/name: node-exporter-iscsi
+    iscsi: sbps
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      iscsi: sbps
+  template:
+    metadata:
+       name: node-exporter-iscsi
+       labels:
+         iscsi: sbps
+    spec:
+      containers:
+      - name: iscsi-container
+        image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 200Mi 
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /iscsi
+          name: sysfs
+          readOnly: true
+        - mountPath: /etc/target/saveconfig.json 
+          name: saveconfig
+          readOnly: true
+        - mountPath: /var/lib/node_exporter
+          name: host-textfile
+          readOnly: false
+      terminationGracePeriodSeconds: 5
+      volumes:
+      - name: sysfs
+        hostPath:
+          path: /sys/kernel/config/target/iscsi/
+      - name: saveconfig
+        hostPath:
+          path: /etc/target/saveconfig.json
+      - name: host-textfile
+        hostPath:
+          path: /var/lib/node_exporter

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -19,11 +19,7 @@ spec:
       containers:
       - name: iscsi-container
         image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
-        {{- if .Values.iscsimetrics.image.pullPolicy }}
         imagePullPolicy: {{ .Values.iscsimetrics.image.pullPolicy }}
-        {{- else }}
-        imagePullPolicy: IfNotPresent
-        {{- end -}}
         resources:
           limits:
             memory: 200Mi 

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: iscsi-container
         image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
-        {{-if .Values.iscsimetrics.image.pullPolicy }}
+        {{- if .Values.iscsimetrics.image.pullPolicy }}
         imagePullPolicy: {{ .Values.iscsimetrics.image.pullPolicy }}
         {{- else }}
         imagePullPolicy: IfNotPresent

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -1192,3 +1192,10 @@ smartmetrics:
     repository: artifactory.algol60.net/csm-docker/stable/quay.io/galexrt/node-exporter-smartmon
     tag: v0.1.1
     pullPolicy: IfNotPresent
+
+iscsimetrics:
+  enabled: true
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/iscsi-metrics
+    tag: v1.0.0
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope
This is  in the context of iSCSI based boot content projection feature. This has the daemonset pod to export iscsi metrics to node exporter / prometheus. 

## Issues and Related PRs
CASMPET-6793

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing
Tested on Odin.

### Tested on: mug
![image](https://github.com/user-attachments/assets/f852bc1f-283b-4d7b-b216-9ae187aae556)