### PR TITLE
CASMMON-413 and CASMMON-424  node_exporter to authenticate itself with its TLS certificate

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.2
+version: 1.0.3
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/node_exporter_webconfig/web.yml
+++ b/kubernetes/cray-sysmgmt-health/node_exporter_webconfig/web.yml
@@ -1,0 +1,3 @@
+tls_server_config:
+  cert_file: /etc/secrets/etcd-client
+  key_file: /etc/secrets/etcd-client-key

--- a/kubernetes/cray-sysmgmt-health/templates/node-exporter/configmap.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/node-exporter/configmap.yaml
@@ -1,0 +1,31 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-config
+  namespace: {{ .Release.Namespace }}
+data:
+  web.yml: |-
+    {{- .Files.Get "node_exporter_webconfig/web.yml" | nindent 4 }}

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -128,8 +128,8 @@ victoria-metrics-k8s-stack:
   # -- Tells helm to remove CRD after chart remove
     cleanupCRD: true
     cleanupImage:
-      repository: artifactory.algol60.net/csm-docker/stable/gcr.io/google_containers/hyperkube
-      tag: v1.18.0
+      repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      tag: 1.24.17
       pullPolicy: IfNotPresent
     createCRD: false
     operator:
@@ -515,7 +515,32 @@ victoria-metrics-k8s-stack:
       requests:
         cpu: "1"
         memory: 1Gi
+    ## Liveness probe
+    ##
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        httpHeaders: []
+        scheme: https
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+
+   ## Readiness probe
+   ##
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        httpHeaders: []
+        scheme: https
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+
     extraArgs:
+      - --web.config.file=/etc/configmap/web.yml
       - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var\/lib\/containerd.+|run/.+)($|/)  # containerd puts container fs's in /run/containerd/
       - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
       - --no-collector.netclass
@@ -531,6 +556,13 @@ victoria-metrics-k8s-stack:
       # tcpstat has potential performance impact
       - --collector.tcpstat
       - --collector.textfile.directory=/var/lib/node_exporter
+    #using same etcd secrets for node exporter https port
+    secrets:
+      - name: etcd-client-cert
+        mountPath: /etc/secrets
+    configmaps:
+      - name: web-config
+        mountPath: /etc/configmap
     extraHostVolumeMounts:
       - mountPath: /var/run/dbus/system_bus_socket
         name: system-dbus-socket
@@ -550,7 +582,24 @@ victoria-metrics-k8s-stack:
         readOnly: true
         mountPropagation: HostToContainer
 
+    vmServiceScrape:
+    # wheter we should create a service scrape resource for node-exporter
+      enabled: true
 
+    # spec for VMServiceScrape crd
+    # https://docs.victoriametrics.com/operator/api.html#vmservicescrapespec
+      spec:
+        jobLabel: jobLabel
+        endpoints:
+          - port: metrics
+            scheme: https
+            tlsConfig:
+              caFile: /etc/vm/secrets/etcd-client-cert/etcd-ca
+              insecureSkipVerify: true
+            metricRelabelConfigs:
+              - action: drop
+                source_labels: [mountpoint]
+                regex: "/var/lib/kubelet/pods.+"
   # Compatibility with dashboards and rules templates
   kube-state-metrics:
     enabled: true

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -556,7 +556,7 @@ victoria-metrics-k8s-stack:
       # tcpstat has potential performance impact
       - --collector.tcpstat
       - --collector.textfile.directory=/var/lib/node_exporter
-    #using same etcd secrets for node exporter https port
+    # using same etcd secrets for node exporter https port
     secrets:
       - name: etcd-client-cert
         mountPath: /etc/secrets


### PR DESCRIPTION
## Summary and Scope
 node_exporter to authenticate itself with its TLS certificate
Fix CVE's in artifactory.algol60.net/csm-docker/stable/gcr.io/google_containers/hyperkube:v1.18.0

system monitoring and metrics collection, ensuring the security of data transmission is paramount. This article delves into the configuration of Transport Layer Security (TLS) and HTTPS for the Prometheus Node Exporter, alongside implementing basic authentication. These measures are critical for safeguarding the integrity and confidentiality of the data as it moves between the Node Exporter and Prometheus server, offering an essential layer of security against potential eavesdropping or unauthorized access.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-424
https://jira-pro.it.hpe.com:8443/browse/CASMMON-413

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on: Mug

from the Master

curl 10.20.214.210:9100/metrics
Client sent an HTTP request to an HTTPS server.

From the worker

![image](https://github.com/user-attachments/assets/8f1a46bf-28ac-4190-a0b8-30f82286e0b8)


