### PR TITLE
CASMTRIAGE-7207: CT ITF triage kubectld pods unhealthy

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.4
+version: 1.0.5
 description: An extension of the official prometheus-operator helm chart for monitoring
   system health.
 keywords:

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -17,6 +17,8 @@ spec:
          iscsi: sbps
     spec:
       containers:
+        nodeSelector:
+          iscsi: sbps
       - name: iscsi-container
         image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
         imagePullPolicy: {{ .Values.iscsimetrics.image.pullPolicy }}

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -17,8 +17,6 @@ spec:
          iscsi: sbps
     spec:
       containers:
-        nodeSelector:
-          iscsi: sbps
       - name: iscsi-container
         image: {{ .Values.iscsimetrics.image.repository }}:{{ .Values.iscsimetrics.image.tag }}  
         imagePullPolicy: {{ .Values.iscsimetrics.image.pullPolicy }}
@@ -38,6 +36,8 @@ spec:
         - mountPath: /var/lib/node_exporter
           name: host-textfile
           readOnly: false
+      nodeSelector:
+        iscsi: sbps
       terminationGracePeriodSeconds: 5
       volumes:
       - name: sysfs


### PR DESCRIPTION
The iSCSI metrics related pods in bad state as iSCSI was not configured/provisioned. This issue is addressed by preventing these pods from scheduling on nodes which do not have iSCSI labels.

## Summary and Scope

This is in the context of CASM-3756 where iSCSI metrics were added via CASMPET-6820. So there are daemonset pods to collect iscsi metrics on each of the worker node where iscsi is configured and Marshal agent is running. But testing on freshly installed CSM 1.6 system these pods failed as iSCSI was not configured. This iscsi will be configured via ansible playbooks. 
But these have to be run manually. This is getting automated which is in progress. 

The other approach to address this issue by preventing these iscsi pods from scheduling on nodes which are not configured with iscsi. So currently this is being done by having node selector (as nodes with iscsi configured will have iscsi=sbps label). 

## Issues and Related PRs

 CASM-3756,  CASMPET-6820, CASMPET-6797

* Resolves [issue id](issue link): CASMTRIAGE-7207

## Testing

Tested on the system where issue encountered: gamora

### Tested on:

Gamora

### Test description:

Required manifest change was done for daemonset manifest file on the system and it is observed that issue is not seen if nodes are not labeled with iscsi. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? - N/A
- Were continuous integration tests run? If not, why? - N/A 
- Was upgrade tested? If not, why? - N/A
- Was downgrade tested? If not, why? - N/A 
- Were new tests (or test issues/Jiras) created for this change? - No

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
