### PR TITLE
CASMMON-432 & CASMTRIAGE-7282 fix set metricsBindAddress and VMINSERT drop metrics more lebels

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.9
+version: 1.0.10
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/kubernetes/persistentvolumesusage.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/kubernetes/persistentvolumesusage.json
@@ -1,4 +1,32 @@
 {
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,7 +52,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 21,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -51,6 +79,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -64,6 +93,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -106,7 +136,6 @@
         "y": 1
       },
       "id": 2,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -120,6 +149,7 @@
           "showLegend": true
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
@@ -200,9 +230,10 @@
         "y": 1
       },
       "id": 3,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -212,9 +243,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": {
@@ -240,6 +272,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -253,6 +286,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -295,7 +329,6 @@
         "y": 8
       },
       "id": 4,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -309,6 +342,7 @@
           "showLegend": true
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
@@ -389,9 +423,10 @@
         "y": 8
       },
       "id": 5,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -401,9 +436,10 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": {
@@ -435,7 +471,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PC96415006F908B67"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -443,6 +479,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -456,6 +493,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -511,6 +549,7 @@
           "showLegend": true
         },
         "tooltip": {
+          "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
@@ -518,8 +557,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PC96415006F908B67"
+            "uid": "$datasource"
           },
           "editorMode": "code",
           "expr": "(  sum without(instance, node) (kubelet_volume_stats_capacity_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"})  -  sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"}))",
@@ -529,11 +567,10 @@
         },
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PC96415006F908B67"
+            "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"})",
+          "expr": "sum without(instance, node) (kubelet_volume_stats_available_bytes{job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"})",
           "hide": false,
           "legendFormat": "Free Space",
           "range": true,
@@ -546,7 +583,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PC96415006F908B67"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -595,6 +632,8 @@
       },
       "id": 9,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -604,17 +643,17 @@
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "11.0.0",
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PC96415006F908B67"
+            "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "(  kubelet_volume_stats_capacity_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"}  -  kubelet_volume_stats_available_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"})/kubelet_volume_stats_capacity_bytes{cluster=\"\", job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"}* 100",
+          "expr": "(  kubelet_volume_stats_capacity_bytes{job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"}  -  kubelet_volume_stats_available_bytes{job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"})/kubelet_volume_stats_capacity_bytes{job=\"kubelet\", metrics_path=\"/metrics\", namespace=\"nexus\", persistentvolumeclaim=\"nexus-data\"}* 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -625,8 +664,7 @@
     }
   ],
   "refresh": "30m",
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "kubernetes-mixin"
   ],
@@ -650,12 +688,7 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
@@ -681,11 +714,7 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "vault",
-          "value": "vault"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
@@ -712,11 +741,7 @@
         "useTags": false
       },
       {
-        "current": {
-          "selected": false,
-          "text": "vault-raft-cray-vault-0",
-          "value": "vault-raft-cray-vault-0"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
@@ -747,6 +772,7 @@
     "from": "now-30m",
     "to": "now"
   },
+  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {
     "refresh_intervals": [
       "5s",
@@ -774,7 +800,7 @@
   },
   "timezone": "",
   "title": "Kubernetes / Persistent Volumes",
-  "uid": "919b92a8e8041bd567af9edab12c840c",
-  "version": 1,
+  "uid": "919b92a8e8041bd567af9edab12c840ca",
+  "version": 2,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
@@ -44,7 +44,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'until kubectl get vmservicescrapes.operator.victoriametrics.com  -n sysmgmt-health vms-kube-scheduler > /dev/null 2>&1; do echo "Waiting for vms-kube-scheduler service monitor to be created"; sleep 5; done; /usr/local/sbin/fix-kubelet-target-down-alert.sh; /usr/local/sbin/disable-alerts.sh; /usr/local/sbin/update-api-alerts.sh'
+            - 'until kubectl get vmservicescrapes.operator.victoriametrics.com  -n sysmgmt-health vms-kube-scheduler > /dev/null 2>&1; do echo "Waiting for vms-kube-scheduler service monitor to be created"; sleep 5; done; fix-kube-proxy-target-down-alert.sh; /usr/local/sbin/disable-alerts.sh; /usr/local/sbin/update-api-alerts.sh'
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: patch-service-monitors

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -192,6 +192,8 @@ victoria-metrics-k8s-stack:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vminsert
           tag: v1.96.0-cluster
         replicaCount: 2
+        extraArgs:
+          maxLabelsPerTimeseries: "100"
         resources:
           limits:
             cpu: '2'


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on: mug

VM not dropping metrics with morethan 40 lebels
 kubectl logs -n sysmgmt-health vminsert-vms-68d95cdfc7-92tmg
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:12   build version: vminsert-20231212-224957-tags-v1.96.0-cluster-0-gd59ee93d0
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:13   command-line flags
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -httpListenAddr=":8480"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -maxLabelsPerTimeseries="100"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -replicationFactor="2"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/lib/logger/flag.go:20     -storageNode="vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400,vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400"
2024-09-11T03:29:17.607Z        info    VictoriaMetrics/app/vminsert/main.go:100        initializing netstorage for storageNodes [vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400 vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400]...
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/memory/memory.go:42 limiting caches to 1288490188 bytes, leaving 858993460 bytes to the OS according to -memory.allowedPercent=60
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/app/vminsert/main.go:119        successfully initialized netstorage in 0.001 seconds
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/httpserver/httpserver.go:101        starting http server at http://127.0.0.1:8480/
2024-09-11T03:29:17.608Z        info    VictoriaMetrics/lib/httpserver/httpserver.go:102        pprof handlers are exposed at http://127.0.0.1:8480/debug/pprof/
2024-09-11T03:29:17.814Z        warn    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:269       cannot dial storageNode "vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400": dial tcp4: lookup vmstorage-vms-1.vmstorage-vms.sysmgmt-health on 10.16.0.10:53: no such host
2024-09-11T03:29:17.814Z        warn    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:269       cannot dial storageNode "vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400": dial tcp4: lookup vmstorage-vms-0.vmstorage-vms.sysmgmt-health on 10.16.0.10:53: no such host
2024-09-11T03:29:47.224Z        info    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:273       successfully dialed -storageNode="vmstorage-vms-0.vmstorage-vms.sysmgmt-health:8400"
2024-09-11T03:29:47.227Z        info    VictoriaMetrics/app/vminsert/netstorage/netstorage.go:273       successfully dialed -storageNode="vmstorage-vms-1.vmstorage-vms.sysmgmt-health:8400"


![image](https://github.com/user-attachments/assets/03a0d241-ea35-4d4a-9e66-a62106e03678)


![Uploading image.png…]()
