### PR TITLE
CASMTRIAGE-7282 fix patch-service-monitors-job to set metricsBindAddress

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.9
+version: 1.0.10
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml
@@ -44,7 +44,7 @@ spec:
             - '/bin/sh'
           args:
             - '-c'
-            - 'until kubectl get vmservicescrapes.operator.victoriametrics.com  -n sysmgmt-health vms-kube-scheduler > /dev/null 2>&1; do echo "Waiting for vms-kube-scheduler service monitor to be created"; sleep 5; done; /usr/local/sbin/fix-kubelet-target-down-alert.sh; /usr/local/sbin/disable-alerts.sh; /usr/local/sbin/update-api-alerts.sh'
+            - 'until kubectl get vmservicescrapes.operator.victoriametrics.com  -n sysmgmt-health vms-kube-scheduler > /dev/null 2>&1; do echo "Waiting for vms-kube-scheduler service monitor to be created"; sleep 5; done; /usr/local/sbin/fix-kube-proxy-target-down-alert.sh; /usr/local/sbin/disable-alerts.sh; /usr/local/sbin/update-api-alerts.sh'
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: patch-service-monitors


### PR DESCRIPTION
## Summary and Scope

The kube-proxy metricsBindAddress should be set in the following way:

```bash
kubectl -n kube-system get cm kube-proxy -o yaml | grep -i metri
metricsBindAddress: 0.0.0.0:10249
```

However, in CSM 1.6, this value is `metricsBindAddress:""`.

In CSM 1.5, the [prometheus/monitors/configmap.yaml](https://github.com/Cray-HPE/cray-sysmgmt-health/blob/release/1.5/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/configmap.yaml) has three bash scripts

- fix-kubelet-target-down-alert.sh
- fix-kube-proxy-target-down-alert.sh
- disable-alerts.sh
These three scripts are then run in the [patch-service-monitors-job.yaml](https://github.com/Cray-HPE/cray-sysmgmt-health/blob/release/1.5/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml#L47).

In CSM 1.6, the [prometheus/monitors/configmap.yaml](https://github.com/Cray-HPE/cray-sysmgmt-health/blob/master/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/configmap.yaml) has DIFFERENT bash scripts. It has the following scripts:

- fix-kube-proxy-target-down-alert.sh
- disable-alerts.sh
- update-api-alerts.sh
Not all of these scripts are referenced correctly in [patch-service-monitors-job.yaml](https://github.com/Cray-HPE/cray-sysmgmt-health/blob/master/kubernetes/cray-sysmgmt-health/templates/prometheus/monitors/patch-service-monitors-job.yaml#L47). This job uses fix-kubelet-target-down-alert.sh instead of fix-kube-proxy-target-down-alert.sh. 

This PR references the correct script from the patch-service-monitors-job.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * Fanta

### Test description:

Before this change, the following was seen on Fanta

```bash
apiVersion: v1
data:
  config.conf: |-
    apiVersion: kubeproxy.config.k8s.io/v1alpha1
    bindAddress: 0.0.0.0
    ...
    metricsBindAddress: ""
    ...
```

I then upgraded the cray-sysmgmt-health chart on Fanta to this chart and saw the `metricsBindAddress` was correct

```bash
apiVersion: v1
data:
  config.conf: |-
    apiVersion: kubeproxy.config.k8s.io/v1alpha1
    bindAddress: 0.0.0.0
    ...
    metricsBindAddress: 0.0.0.0:10249
    ...
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

