### PR TITLE
CASMPET-7238:/etc/target/saveconfig.json exists as a dir instead of file

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.13
+version: 1.0.14
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/iscsi/iscsi_daemon.yaml
@@ -30,7 +30,7 @@ spec:
         - mountPath: /iscsi
           name: sysfs
           readOnly: true
-        - mountPath: /etc/target/saveconfig.json 
+        - mountPath: /etc/target/
           name: saveconfig
           readOnly: true
         - mountPath: /var/lib/node_exporter
@@ -45,7 +45,7 @@ spec:
           path: /sys/kernel/config/target/iscsi/
       - name: saveconfig
         hostPath:
-          path: /etc/target/saveconfig.json
+          path: /etc/target/
       - name: host-textfile
         hostPath:
           path: /var/lib/node_exporter


### PR DESCRIPTION
## Summary and Scope
This issue is caused due to hostpath /etc/target/saveconfig.json not existed when iscsi_daemon.yaml was deployed. Mounting '/etc/target/' directory instead of '/etc/target/saveconfig.json' fixed the issue.

## Issues and Related PRs
None.

* Resolves [issue id](issue link): CASMPET-7238
* Change will also be needed in `<insert branch name here>`: N/A
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A 
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
Tested on both Starlord and Fanta having CSM 1.6.0-alpha.67 installed. 

### Tested on:
Starlord and Fanta

### Test description:
Reproduced the issue when iSCSI was not configured. /etc/target/saveconfig.json directory got created on host as this file was not existed (iSCSI was not configured). When iSCSI was configured via CFS ansible play books, it tried to create /etc/target/saveconfig.json file. But since there was a directory /etc/target/saveconfig.json/ , /etc/target/saveconfig.json/saveconfig.json.temp file got created. 

Fix verification: Edited the daemonset "kubectl edit cray-sysmgmt-health-node-exporter-iscsi -n sysmgmt-health" to mount "/etc/target" and issue is not seen.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: Yes
- Were continuous integration tests run? If not, why?: TBD
- Was upgrade tested? If not, why?: TBD
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: No

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
