### PR TITLE
CASMMON-458 Victoriametrics Upgrate

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.0.17
+version: 1.0.18
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health
@@ -41,7 +41,7 @@ sources:
 dependencies:
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.17.5
+  version: 0.24.5
 - name: prometheus-snmp-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 1.1.0
@@ -55,7 +55,7 @@ dependencies:
 maintainers:
 - name: rambabubolla
 - name: shreniagrawal
-appVersion: 0.17.5
+appVersion: 0.24.5
 annotations:
   artifacthub.io/images: |
     - name: alertmanager

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -152,7 +152,7 @@ victoria-metrics-k8s-stack:
     enabled: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/operator
-      tag: v0.35.1
+      tag: v0.46.4
       pullPolicy: IfNotPresent
     env:
       - name: VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE
@@ -162,8 +162,8 @@ victoria-metrics-k8s-stack:
   # -- Tells helm to remove CRD after chart remove
     cleanupCRD: true
     cleanupImage:
-      repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.24.17
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+      tag: 1.31.1
       pullPolicy: IfNotPresent
     createCRD: false
     operator:
@@ -179,7 +179,7 @@ victoria-metrics-k8s-stack:
       vmstorage:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmstorage
-          tag: v1.93.1-cluster
+          tag: v1.102.1-cluster
         replicaCount: 2
         resources:
           limits:
@@ -198,7 +198,7 @@ victoria-metrics-k8s-stack:
       vmselect:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmselect
-          tag: v1.93.1-cluster
+          tag: v1.102.1-cluster
         replicaCount: 2
         resources:
           limits:
@@ -217,7 +217,7 @@ victoria-metrics-k8s-stack:
       vminsert:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vminsert
-          tag: v1.96.0-cluster
+          tag: v1.102.1-cluster
         replicaCount: 2
         extraArgs:
           maxLabelsPerTimeseries: "100"
@@ -251,7 +251,7 @@ victoria-metrics-k8s-stack:
       selectAllByDefault: true
       image:
         repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmagent
-        tag: v1.93.1
+        tag: v1.102.1
       secrets:
         - etcd-client-cert
       resources:
@@ -389,7 +389,8 @@ victoria-metrics-k8s-stack:
     downloadDashboards:
       securityContext: {}
     downloadDashboardsImage:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/curlimages/curl
       tag: 7.81.0
       sha: ""
       pullPolicy: IfNotPresent
@@ -431,7 +432,8 @@ victoria-metrics-k8s-stack:
 
     sidecar:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/kiwigrid/k8s-sidecar
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/docker.io/kiwigrid/k8s-sidecar
         tag: 0.1.151
       dashboards:
         enabled: true
@@ -474,8 +476,10 @@ victoria-metrics-k8s-stack:
           isDefault: true
 
     testFramework:
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bats/bats
-      tag: v1.4.1
+      image:
+        registry: artifactory.algol60.net
+        image: csm-docker/stable/docker.io/bats/bats
+        tag: v1.4.1
 
   # Exporters
   kubelet:
@@ -678,7 +682,8 @@ victoria-metrics-k8s-stack:
         - 'downwardAPI'
         - 'persistentVolumeClaim'
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kube-state-metrics
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/bitnami/kube-state-metrics
       tag: v2.8.0
     collectors:
       - certificatesigningrequests


### PR DESCRIPTION
## Summary and Scope

Upgraded VM from to resolve vulnerability
https://github.com/VictoriaMetrics/helm-charts/tree/master/charts/victoria-metrics-k8s-stack

Victoria metrics components:
Vmselect
Vmagent
Vmalert
Vmstorage

## Issues and Related PRs
[
_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`](https://jira-pro.it.hpe.com:8443/browse/CASMMON-458)

## Testing

_List the environments in which these changes were tested._

### Tested on: Starlord

![image](https://github.com/user-attachments/assets/4dffd6f5-63d9-48be-b140-74abef07b051)


![image](https://github.com/user-attachments/assets/13aec60c-e23d-420e-82dc-43e6eb88d82d)


![image](https://github.com/user-attachments/assets/297dc9ff-508b-4ea6-ab13-0fce71be0de1)


uninstall script logs

helm uninstall -n sysmgmt-health cray-sysmgmt-health --debug
uninstall.go:102: [debug] uninstall: Deleting cray-sysmgmt-health
client.go:142: [debug] creating 1 resource(s)
client.go:142: [debug] creating 1 resource(s)
client.go:142: [debug] creating 1 resource(s)
client.go:142: [debug] creating 1 resource(s)
client.go:712: [debug] Watching for changes to Job cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook with timeout of 5m0s
client.go:740: [debug] Add/Modify event for cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: ADDED
client.go:779: [debug] cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: Jobs active: 0, jobs failed: 0, jobs succeeded: 0
client.go:740: [debug] Add/Modify event for cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: MODIFIED
client.go:779: [debug] cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:740: [debug] Add/Modify event for cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: MODIFIED
client.go:779: [debug] cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:740: [debug] Add/Modify event for cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: MODIFIED
client.go:779: [debug] cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: Jobs active: 1, jobs failed: 0, jobs succeeded: 0
client.go:740: [debug] Add/Modify event for cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook: MODIFIED
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook" ClusterRole
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook" ClusterRoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator-cleanup-hook" Job
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-logstash-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-snmp-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-node-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-canu-test" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-gitea-vcs-postgres-exporter" Service
client.go:486: [debug] Starting delete for "vms-coredns" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-spire-postgres-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-rm-pals-postgres-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-smd-postgres-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-sma-postgres-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grok-exporter" Service
client.go:486: [debug] Starting delete for "vms-kube-controller-manager" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-sls-postgres-exporter" Service
client.go:486: [debug] Starting delete for "vms-kube-etcd" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-node-exporter" Service
client.go:486: [debug] Starting delete for "vms-kube-scheduler" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-keycloak-postgres-exporter" Service
client.go:486: [debug] Starting delete for "vms-kube-proxy" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-dhcp-kea-exporter" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" Service
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish-cron" CronJob
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-patch-service-monitors-1" Job
client.go:490: [debug] Ignoring delete failure for "cray-sysmgmt-health-patch-service-monitors-1" batch/v1, Kind=Job: jobs.batch "cray-sysmgmt-health-patch-service-monitors-1" not found
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grok-exporter" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-snmp-exporter" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-canu-test" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish-exporter" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-logstash-exporter" Deployment
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-smartmon" DaemonSet
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-node-exporter" DaemonSet
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-iscsi" DaemonSet
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-patcher" RoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-snmp-exporter" RoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" RoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" RoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-patcher" Role
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-snmp-exporter" Role
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" Role
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" Role
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" ClusterRoleBinding
client.go:486: [debug] Starting delete for "patch-service-monitors" ClusterRoleBinding
client.go:486: [debug] Starting delete for "psp-cray-sysmgmt-health-kube-state-metrics" ClusterRoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" ClusterRoleBinding
client.go:486: [debug] Starting delete for "metrics-endpoint" ClusterRoleBinding
client.go:486: [debug] Starting delete for "psp-cray-sysmgmt-health-prometheus-node-exporter" ClusterRoleBinding
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana-clusterrolebinding" ClusterRoleBinding
client.go:486: [debug] Starting delete for "psp-cray-sysmgmt-health-kube-state-metrics" ClusterRole
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana-clusterrole" ClusterRole
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" ClusterRole
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" ClusterRole
client.go:486: [debug] Starting delete for "psp-cray-sysmgmt-health-prometheus-node-exporter" ClusterRole
client.go:486: [debug] Starting delete for "secure-metrics-scrape" ClusterRole
client.go:486: [debug] Starting delete for "patch-service-monitors" ClusterRole
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana-config-dashboards" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" ConfigMap
client.go:486: [debug] Starting delete for "vms-grafana-ds" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-canu-test" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-osd-device-details" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-cephfs-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-full" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-cluster" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-radosgw-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-rbd-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-etcd" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-osds-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-workload-total" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-namespace-by-workload" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-workload" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-pool-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-istio-workload-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-cluster-rsrc-use" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-cluster" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-greenlight-redlight" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-persistentvolumesusage" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-radosgw-detail" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-opensearch" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-pod-total" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-istio-performance-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-controller-manager" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-zookeeper" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-postgresql" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-hosts-overview" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-apiserver" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-host-details" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-microservice-health-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-pool-detail" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubelet" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-smartmon" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-namespace-by-pod" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-workloads-namespace" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-istio-mesh-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-nodenetwork" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vmagent" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-pilot-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kea-dhcp" ConfigMap
client.go:486: [debug] Starting delete for "web-config" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-goss-tests" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-critical-services-monitoring-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-pod" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-coredns" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kyverno" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vmalert" ConfigMap
client.go:486: [debug] Starting delete for "patch-service-monitors" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-nodes" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-snmpstats" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-operator" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-namespace" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-proxy" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-iuf-timing" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-scheduler" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-statefulset" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana-dashboards-default" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-iscsi" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-unbound-dns" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-network-exporter" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-logstash" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kafka" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-hardware-temperature" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kafka-connect" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-snmp-interface-detail" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-timescaledb" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-cluster-total" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-k8s-resources-node" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-istio-service-dashboard" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-rsrc-use" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-fluentbit" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grok-exporter" ConfigMap
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-canu-test-secrets" Secret
client.go:486: [debug] Starting delete for "alertmanager-config" Secret
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" Secret
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish-exporter" Secret
client.go:486: [debug] Starting delete for "vms" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter-hook" ServiceAccount
client.go:486: [debug] Starting delete for "patch-service-monitors" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-snmp-exporter" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-redfish-exporter" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-node-exporter" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-victoria-metrics-operator" ServiceAccount
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-prometheus-node-exporter" PodSecurityPolicy
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" PodSecurityPolicy
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" PodSecurityPolicy
W1115 06:31:06.332228  679491 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1115 06:31:06.333676  679491 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1115 06:31:06.333903  679491 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-alertmanager" DestinationRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vm-select" DestinationRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" DestinationRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vm-agent" DestinationRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-node-exporter" Endpoints
client.go:486: [debug] Starting delete for "vms-kube-etcd" Endpoints
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-exporter" Endpoints
client.go:490: [debug] Ignoring delete failure for "cray-sysmgmt-health-ceph-node-exporter" /v1, Kind=Endpoints: endpoints "cray-sysmgmt-health-ceph-node-exporter" not found
client.go:490: [debug] Ignoring delete failure for "cray-sysmgmt-health-ceph-exporter" /v1, Kind=Endpoints: endpoints "cray-sysmgmt-health-ceph-exporter" not found
client.go:490: [debug] Ignoring delete failure for "vms-kube-etcd" /v1, Kind=Endpoints: endpoints "vms-kube-etcd" not found
client.go:486: [debug] Starting delete for "vms" VMAgent
client.go:490: [debug] Ignoring delete failure for "vms" operator.victoriametrics.com/v1beta1, Kind=VMAgent: vmagents.operator.victoriametrics.com "vms" not found
client.go:486: [debug] Starting delete for "vms" VMAlert
client.go:490: [debug] Ignoring delete failure for "vms" operator.victoriametrics.com/v1beta1, Kind=VMAlert: vmalerts.operator.victoriametrics.com "vms" not found
client.go:486: [debug] Starting delete for "vms" VMAlertmanager
client.go:490: [debug] Ignoring delete failure for "vms" operator.victoriametrics.com/v1beta1, Kind=VMAlertmanager: vmalertmanagers.operator.victoriametrics.com "vms" not found
client.go:486: [debug] Starting delete for "vms" VMCluster
client.go:490: [debug] Ignoring delete failure for "vms" operator.victoriametrics.com/v1beta1, Kind=VMCluster: vmclusters.operator.victoriametrics.com "vms" not found
client.go:486: [debug] Starting delete for "vms-kubelet" VMNodeScrape
client.go:486: [debug] Starting delete for "vms-probes" VMNodeScrape
client.go:486: [debug] Starting delete for "vms-cadvisor" VMNodeScrape
client.go:486: [debug] Starting delete for "kafka-resources-metrics" VMPodScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-pods" VMPodScrape
client.go:486: [debug] Starting delete for "entity-operator-metrics" VMPodScrape
client.go:486: [debug] Starting delete for "metallb-speaker" VMPodScrape
client.go:486: [debug] Starting delete for "metallb-controller" VMPodScrape
client.go:486: [debug] Starting delete for "vms-alertmanager.rules" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.podowner" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containermemorycache" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containermemoryswap" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containermemoryworkingsetbytes" VMRule
client.go:486: [debug] Starting delete for "vms-general.rules" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containermemoryrss" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containercpuusagesecondstotal" VMRule
client.go:486: [debug] Starting delete for "vms-etcd" VMRule
client.go:486: [debug] Starting delete for "vms-k8s.rules.containerresource" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-system-controller-manager" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-switch-alerts.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kube-apiserver-slos" VMRule
client.go:486: [debug] Starting delete for "vms-node-network" VMRule
client.go:486: [debug] Starting delete for "vms-vm-health" VMRule
client.go:486: [debug] Starting delete for "vms-kubelet.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-state-metrics" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-disk-space.rules" VMRule
client.go:486: [debug] Starting delete for "vms-vmagent" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-mdraid-prometheus-alert.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-system-apiserver" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-resources" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-system-kubelet" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-system" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-system-controller-manager" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-storage" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-general.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-prometheus-alert.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-apps" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-postgresql-prometheus-alert.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-system-scheduler" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-system-scheduler" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-istio-alerts.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-resources" VMRule
client.go:486: [debug] Starting delete for "vms-kube-prometheus-node-recording.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-storage" VMRule
client.go:486: [debug] Starting delete for "vms-node-exporter" VMRule
client.go:486: [debug] Starting delete for "vms-kube-scheduler.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kube-state-metrics" VMRule
client.go:486: [debug] Starting delete for "vms-kube-apiserver-histogram.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-system-kubelet" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-apiserver-slos" VMRule
client.go:486: [debug] Starting delete for "vms-kube-apiserver-availability.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-etcd" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kube-scheduler.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-system" VMRule
client.go:486: [debug] Starting delete for "vms-kube-prometheus-general.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-prometheus.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kubernetes-system-apiserver" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kea-dhcp-alerts.rules" VMRule
client.go:486: [debug] Starting delete for "vms-vmcluster" VMRule
client.go:486: [debug] Starting delete for "vms-node.rules" VMRule
client.go:486: [debug] Starting delete for "vms-kube-apiserver-burnrate.rules" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-network" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-kubernetes-apps" VMRule
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-node-exporter.rules" VMRule
client.go:486: [debug] Starting delete for "vms-vmsingle" VMRule
client.go:486: [debug] Starting delete for "metallb" VMRule
client.go:486: [debug] Starting delete for "vms-node-exporter.rules" VMRule
client.go:486: [debug] Starting delete for "vms-apiserver" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-cray-dns-unbound--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-kube-etcd" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-kube-controller-manager" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-hbtd-etcd-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-argo-only-argo-workflows-workflow-controlle" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-dhcp-kea-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-operator" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-bss-etcd-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-node-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-canu-test--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-spire-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-snmp-exporter-sw-spine-02" VMServiceScrape
client.go:486: [debug] Starting delete for "fluentbit-collector" VMServiceScrape
client.go:486: [debug] Starting delete for "fluentbit-aggregator" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-coredns" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-rm-pals-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-ceph-node-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-sls-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-smd-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-hmnfd-etcd-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-uas-mgr-etcd-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-gitea-vcs-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-fas-etcd-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-keycloak-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-cray-kyverno-svc-metrics--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-logstash--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grok-exporter--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-kube-scheduler" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-sma-postgres-exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-kube-state-metrics" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-powerdns--exporter" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-snmp-exporter-sw-spine-01" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-grafana" VMServiceScrape
client.go:486: [debug] Starting delete for "vms-kube-proxy" VMServiceScrape
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vm-select" VirtualService
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-grafana" VirtualService
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-alertmanager" VirtualService
client.go:486: [debug] Starting delete for "cray-sysmgmt-health-vm-agent" VirtualService
uninstall.go:155: [debug] purge requested for cray-sysmgmt-health
release "cray-sysmgmt-health" uninstalled
ncn-m001:~/ram/final/24-5 #

