### PR TITLE
grafana and node exporter image issues for Victoria metrics 0.24.5

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.1.0
+version: 1.1.1
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -384,7 +384,8 @@ victoria-metrics-k8s-stack:
       hosts:
         - grafana.domain.com
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/grafana/grafana
       tag: 11.0.0
     downloadDashboards:
       securityContext: {}
@@ -569,7 +570,8 @@ victoria-metrics-k8s-stack:
       container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
 
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/node-exporter
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/prometheus/node-exporter
       tag: v1.5.0
     resources:
       limits:


### PR DESCRIPTION
## Summary and Scope
grafana and node exporter image issues for Victoria metrics 0.24.5

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMMON-458
## Testing

_List the environments in which these changes were tested._

### Tested on: startloard

 helm template cray-sysmgmt-health | grep image: | grep "/artifactory"

![image](https://github.com/user-attachments/assets/87501e02-1290-43b4-b344-e1701e0a7a48)
