### PR TITLE
CASMTRIAGE-7490: Couple of Iscsi metrics values are not correct

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.1.3
+version: 1.1.4
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -1258,5 +1258,5 @@ iscsimetrics:
   enabled: true
   image:
     repository: artifactory.algol60.net/csm-docker/stable/iscsi-metrics
-    tag: 1.0.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary and Scope
Couple of iSCSI SBPS metrics  values are not correct due to old image of iscsi-metrics where this issue has been fixed in 1.0.1 of iscsi-metrics image. Updating 'cray-sysmgtmt-health' chart to use 1.0.1 of iscsi-metrics image and update the chart version.

## Issues and Related PRs
CASMTRIAGE-7285

* Resolves [issue id](issue link): CASMTRIAGE-7490:

## Testing
Testing was done on fanta as part of CASMTRIAGE-7285. 

### Test description:
iscsi-metrics image with 1.0.1 version was downloaded manually onto the system and tested. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: N/A 
- Was downgrade tested? If not, why?: N/A
- Were new tests (or test issues/Jiras) created for this change?: No

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

