### PR TITLE
CASMMON-508 VM upgrade 0.42.0

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.2.8
+version: 1.2.9
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health
@@ -41,7 +41,7 @@ sources:
 dependencies:
 - name: victoria-metrics-k8s-stack
   repository: https://victoriametrics.github.io/helm-charts
-  version: 0.24.5
+  version: 0.42.0
 - name: prometheus-snmp-exporter
   repository: https://prometheus-community.github.io/helm-charts
   version: 7.0.0
@@ -55,7 +55,7 @@ dependencies:
 maintainers:
 - name: rambabubolla
 - name: shreniagrawal
-appVersion: 0.24.5
+appVersion: 0.42.0
 annotations:
   artifacthub.io/images: |
     - name: alertmanager

--- a/kubernetes/cray-sysmgmt-health/templates/alertmanager/alertmanager.yaml
+++ b/kubernetes/cray-sysmgmt-health/templates/alertmanager/alertmanager.yaml
@@ -6,8 +6,8 @@ metadata:
   name: alertmanager-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager
-{{ include "victoria-metrics-k8s-stack.labels" . | indent 4 }}
+    app.kubernetes.io/component: {{ include "vm.name" $ }}-alertmanager
+{{ include "vm.labels" . | indent 4 }}
 stringData:
   alertmanager.yaml: {{ toYaml .Values.alertmanagerSecret.configAlertmanager  | quote }}
 {{- end }}

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -145,6 +145,11 @@ victoria-metrics-k8s-stack:
   labels:
     release: cray-sysmgmt-health
   defaultDashboardsEnabled: false
+  defaultDashboards:
+  # -- Enable custom dashboards installation
+    enabled: false
+    labels:
+      release: cray-sysmgmt-health
   vmselect:
     vmselectSpec:
       externalAuthority: vmselect.local
@@ -152,19 +157,24 @@ victoria-metrics-k8s-stack:
     enabled: true
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/operator
-      tag: v0.46.4
+      tag: v0.55.0
       pullPolicy: IfNotPresent
     env:
       - name: VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE
-        value: artifactory.algol60.net/csm-docker/stable/docker.io/prom/prometheus-config-reloader:v0.62.0
+        value: artifactory.algol60.net/csm-docker/stable/docker.io/prom/prometheus-config-reloader:v0.81.0
       - name: VM_VMALERTDEFAULT_CONFIGRELOADIMAGE
-        value: artifactory.algol60.net/csm-docker/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
+        value: artifactory.algol60.net/csm-docker/stable/docker.io/jimmidyson/configmap-reload:v0.9.0
   # -- Tells helm to remove CRD after chart remove
+    crds:
+    # -- added temporary, till new operator version released
+      plain: true
+      cleanup:
+        enabled: true
+        image:
+          repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+          tag: 1.31.1
+          pullPolicy: IfNotPresent
     cleanupCRD: true
-    cleanupImage:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.31.1
-      pullPolicy: IfNotPresent
     createCRD: false
     operator:
     # -- By default, operator converts prometheus-operator objects.
@@ -179,7 +189,7 @@ victoria-metrics-k8s-stack:
       vmstorage:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmstorage
-          tag: v1.102.1-cluster
+          tag: v1.115.0-cluster
         replicaCount: 2
         resources:
           limits:
@@ -198,7 +208,7 @@ victoria-metrics-k8s-stack:
       vmselect:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmselect
-          tag: v1.102.1-cluster
+          tag: v1.115.0-cluster
         replicaCount: 2
         resources:
           limits:
@@ -217,7 +227,7 @@ victoria-metrics-k8s-stack:
       vminsert:
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vminsert
-          tag: v1.102.1-cluster
+          tag: v1.115.0-cluster
         replicaCount: 2
         extraArgs:
           maxLabelsPerTimeseries: "100"
@@ -234,7 +244,7 @@ victoria-metrics-k8s-stack:
     spec:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmalert
-        tag: v1.102.0
+        tag: v1.115.0
       resources:
         limits:
           cpu: '2'
@@ -251,7 +261,7 @@ victoria-metrics-k8s-stack:
       selectAllByDefault: true
       image:
         repository: artifactory.algol60.net/csm-docker/stable/docker.io/victoriametrics/vmagent
-        tag: v1.102.1
+        tag: v1.115.0
       secrets:
         - etcd-client-cert
       resources:
@@ -345,7 +355,7 @@ victoria-metrics-k8s-stack:
     spec:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/quay.io/prometheus/alertmanager
-        tag: v0.25.0
+        tag: v0.28.1
       containers:
       - name: config-reloader
         image: artifactory.algol60.net/csm-docker/stable/docker.io/jimmidyson/configmap-reload:v0.3.0
@@ -393,7 +403,7 @@ victoria-metrics-k8s-stack:
     downloadDashboardsImage:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/curlimages/curl
-      tag: 7.81.0
+      tag: 8.13.0
       sha: ""
       pullPolicy: IfNotPresent
     env:
@@ -436,7 +446,7 @@ victoria-metrics-k8s-stack:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/kiwigrid/k8s-sidecar
-        tag: 0.1.151
+        tag: 1.30.3
       dashboards:
         enabled: true
         label: grafana_dashboard
@@ -482,7 +492,7 @@ victoria-metrics-k8s-stack:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bats/bats
-        tag: v1.4.1
+        tag: 1.11.1
 
   # Exporters
   kubelet:
@@ -574,7 +584,7 @@ victoria-metrics-k8s-stack:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/prometheus/node-exporter
-      tag: v1.5.0
+      tag: v1.9.1
     resources:
       limits:
         cpu: "6"
@@ -649,7 +659,7 @@ victoria-metrics-k8s-stack:
         readOnly: true
         mountPropagation: HostToContainer
 
-    vmServiceScrape:
+    vmScrape:
     # wheter we should create a service scrape resource for node-exporter
       enabled: true
 


### PR DESCRIPTION
## Summary and Scope

Victoriametrics upgrade from 0.25.0 to 0.42.0
upgrade node exporter

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMMON-481
https://jira-pro.it.hpe.com:8443/browse/CASMMON-482


## Testing

_List the environments in which these changes were tested._

### Tested on: starlaord

Installtion logs
 loftsman ship --manifest-path ./shs-cust.yaml --charts-path .
2025-04-17T07:16:13Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2025-04-17T07:16:13Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2025-04-17T07:16:13Z INF Ensuring that the loftsman namespace exists command=ship
2025-04-17T07:16:13Z INF Loftsman will use the packaged charts at . as the Helm install source command=ship
2025-04-17T07:16:13Z INF Running a release for the provided manifest at ./shs-cust.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-sysmgmt-health v1.2.9-20250417071346+e80b96e
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-04-17T07:16:13Z INF Found value overrides for chart, applying:
cephExporter:
  endpoints:
  - 10.252.1.11
  - 10.252.1.12
  - 10.252.1.13
cephNodeExporter:
  enabled: true
  endpoints:
  - 10.252.1.11
  - 10.252.1.12
  - 10.252.1.13
imageHost: registry.local
victoria-metrics-k8s-stack:
  alertmanager:
    externalAuthority: alertmanager.cmn.starlord.hpc.amslabs.hpecorp.net
    externalUrl: https://alertmanager.cmn.starlord.hpc.amslabs.hpecorp.net/
  grafana:
    externalAuthority: grafana.cmn.starlord.hpc.amslabs.hpecorp.net
    plugins: ""
  kubeEtcd:
    endpoints:
    - 10.252.1.4
    - 10.252.1.5
    - 10.252.1.6
  prometheus-node-exporter:
    resources:
      requests:
        cpu: 10m
  vmagent:
    vmagentSpec:
      externalAuthority: vmagent.cmn.starlord.hpc.amslabs.hpecorp.net
      externalUrl: https://vmagent.cmn.starlord.hpc.amslabs.hpecorp.net/
  vmselect:
    vmselectSpec:
      externalAuthority: vmselect.cmn.starlord.hpc.amslabs.hpecorp.net
      externalUrl: https://vmselect.cmn.starlord.hpc.amslabs.hpecorp.net/
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.2.9-20250417071346+e80b96e
2025-04-17T07:16:13Z INF Running helm install/upgrade with arguments: upgrade --install cray-sysmgmt-health cray-sysmgmt-health-1.2.9-20250417071346+e80b96e.tgz --namespace sysmgmt-health --create-namespace --set global.chart.name=cray-sysmgmt-health --set global.chart.version=1.2.9-20250417071346+e80b96e -f /tmp/loftsman-1744874173/cray-sysmgmt-health-values.yaml chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.2.9-20250417071346+e80b96e
2025-04-17T07:16:43Z INF Release "cray-sysmgmt-health" does not exist. Installing it now.
W0417 07:16:36.122946  721761 warnings.go:70] spec.template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/node-exporter]: deprecated since v1.30; use the "appArmorProfile" field instead
W0417 07:16:36.138341  721761 warnings.go:70] spec.template.spec.containers[1].env[7]: hides previous definition of "GF_PATHS_PLUGINS", which may be dropped when using apply
NAME: cray-sysmgmt-health
LAST DEPLOYED: Thu Apr 17 07:16:14 2025
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 1
 chart=cray-sysmgmt-health command=ship namespace=sysmgmt-health version=1.2.9-20250417071346+e80b96e
2025-04-17T07:16:43Z INF Ship status: success. Recording status, manifest to configmap loftsman-cray-sysmgmt-health in namespace loftsman command=ship
2025-04-17T07:16:43Z INF Recording log data to configmap loftsman-cray-sysmgmt-health-ship-log in namespace loftsman command=ship


uninstallation logs
=========

 helm uninstall -n sysmgmt-health cray-sysmgmt-health                                                                              release "cray-sysmgmt-health" uninstalled


![image](https://github.com/user-attachments/assets/173b6d73-305a-441b-9186-1cca88a723f4)

![image](https://github.com/user-attachments/assets/bb596e4d-6672-4dff-bb37-3ec8cec03aec)


![image](https://github.com/user-attachments/assets/0eb8ebc0-44d2-4732-84b5-35f4f1c6af8d)

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Grafana dashboards

![image](https://github.com/user-attachments/assets/a9196adf-c2ec-44b5-875a-e0f2390bbb69)

![image](https://github.com/user-attachments/assets/8d3c9383-75b1-401e-86c3-db6e2c7e453b)

