### PR TITLE
CASMMON-511 create grok exporter docker image for cray-sysmgmt-health

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.2.3
+version: 1.2.4
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/dashboards_json/logstash/logstash.json
+++ b/kubernetes/cray-sysmgmt-health/dashboards_json/logstash/logstash.json
@@ -2167,7 +2167,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -2402,7 +2402,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -2506,7 +2506,7 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -2624,7 +2624,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -2732,7 +2732,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -2852,7 +2852,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.4.7",
+      "pluginVersion": "11.5.2",
       "repeat": "pod",
       "repeatDirection": "h",
       "targets": [
@@ -3077,8 +3077,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Logstash-Test",
-  "uid": "Logstash-Test",
+  "title": "Logstash",
+  "uid": "fdy9m1ui16mf4a",
   "version": 1,
   "weekStart": ""
 }

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -55,7 +55,7 @@ canuTest:
 grokExporter:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/grok-exporter/grok-exporter
-    tag: latest
+    tag: v1.0.0.RC5
     pullPolicy: IfNotPresent
 
 kubectl:


### PR DESCRIPTION
## Summary and Scope

create grok exporter docker image for cray-sysmgmt-health

## Issues and Related PRs

* Related to https://jira-pro.it.hpe.com:8443/browse/CASMMON-511

## Testing

### Tested on:

  * wasp

![image](https://github.com/user-attachments/assets/00aa72dd-b752-410e-95bf-6bda6709a2d0)


