### PR TITLE
CASMPET-6561: Update kube-state-metrics image to version 2.15.0

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.2.3
+version: 1.2.4
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -687,7 +687,7 @@ victoria-metrics-k8s-stack:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kube-state-metrics
-      tag: v2.8.0
+      tag: 2.15.0
     collectors:
       - certificatesigningrequests
       - configmaps


### PR DESCRIPTION
## Summary and Scope

The `kube-state-metrics` image v2.8.0 has many CVEs and needs to be updated.  With K8s 1.32 in CSM 1.7, the `kube-state-metrics` version recommended for K8s 1.32 is 2.15.0.  Updating the image to 2.15.0.

## Issues and Related PRs

* Resolves [CASMPET-6561](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6561)

## Testing
Installed on vShasta `molly` running K8s 1.32.2.  All K8s pods in `Running` status.  Able to connect to `kube-state-metrics` service.

```
ncn-m001:~/studenym # helm upgrade -n sysmgmt-health cray-sysmgmt-health cray-sysmgmt-health-1.2.4-20250321190703+6e8066b.tgz
Release "cray-sysmgmt-health" has been upgraded. Happy Helming!
NAME: cray-sysmgmt-health
LAST DEPLOYED: Fri Mar 21 19:13:29 2025
NAMESPACE: sysmgmt-health
STATUS: deployed
REVISION: 5
pit:~ # kubectl get pods -n sysmgmt-health | grep cray-sysmgmt
cray-sysmgmt-health-canu-test-6945887cb8-bvrtn                   2/2     Running     0             6d22h
cray-sysmgmt-health-grafana-665777dc5d-kzzvw                     2/2     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-6wld2                1/1     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-94tqf                1/1     Running     0             6d22h
cray-sysmgmt-health-grok-exporter-f5cd5494d-ftqx6                1/1     Running     0             6d22h
cray-sysmgmt-health-kube-state-metrics-88695fd6f-pdv9h           1/1     Running     0             3d23h
cray-sysmgmt-health-logstash-exporter-7b475899cc-hx6dg           1/1     Running     0             2d22h
cray-sysmgmt-health-node-exporter-smartmon-4qdbt                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-9vbmv                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-k8vzr                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-mmq6s                 1/1     Running     0             6d20h
cray-sysmgmt-health-node-exporter-smartmon-p42k2                 1/1     Running     0             6d22h
cray-sysmgmt-health-node-exporter-smartmon-rbrbg                 1/1     Running     0             6d22h
cray-sysmgmt-health-patch-service-monitors-5-5kbxf               0/1     Completed   0             2d22h
cray-sysmgmt-health-prometheus-node-exporter-5gjt2               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-ck7wt               1/1     Running     0             6d20h
cray-sysmgmt-health-prometheus-node-exporter-ldr2g               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-pw96d               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-qr98w               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-node-exporter-wbqpx               1/1     Running     0             6d22h
cray-sysmgmt-health-prometheus-snmp-exporter-7985b57977-gqzz4    1/1     Running     0             6d22h
cray-sysmgmt-health-redfish-cron-29046240-kh5gw                  0/1     Completed   0             17h
cray-sysmgmt-health-redfish-cron-29046600-d9ffq                  0/1     Completed   0             11h
cray-sysmgmt-health-redfish-cron-29046960-xvckw                  0/1     Completed   0             5h56m
cray-sysmgmt-health-redfish-exporter-7477b757c6-lgw9g            1/1     Running     0             6d22h
cray-sysmgmt-health-victoria-metrics-operator-6cc697fb8d-dk9gb   1/1     Running     0             6d22h
pit:~ # helm history -n sysmgmt-health cray-sysmgmt-health
REVISION	UPDATED                 	STATUS    	CHART                                           	APP VERSION	DESCRIPTION
1       	Mon Mar 17 19:04:40 2025	superseded	cray-sysmgmt-health-1.2.1                       	0.24.5     	Install complete
2       	Thu Mar 20 18:36:54 2025	superseded	cray-sysmgmt-health-1.2.3                       	0.24.5     	Upgrade complete
3       	Thu Mar 20 18:39:48 2025	superseded	cray-sysmgmt-health-1.2.1                       	0.24.5     	Rollback to 1
4       	Thu Mar 20 18:50:24 2025	superseded	cray-sysmgmt-health-1.2.2                       	0.24.5     	Upgrade complete
5       	Fri Mar 21 19:13:29 2025	deployed  	cray-sysmgmt-health-1.2.4-20250321190703+6e8066b	0.24.5     	Upgrade complete
pit:~ #
```
![image](https://github.com/user-attachments/assets/22de04c6-1f48-43a1-b309-f1c547ed537f)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

