### PR TITLE
bump up chart version to 1.2.5

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.2.4
+version: 1.2.5
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health


### PR DESCRIPTION
## Summary and Scope

This PR is to bump up the version of chart to 1.2.5 that was missed in the previous merge from this branch.
