### PR TITLE
CASMMON-543 upgrade bitnami/kubectl image to 1.33.1

### DIFF
--- a/kubernetes/cray-sysmgmt-health/Chart.yaml
+++ b/kubernetes/cray-sysmgmt-health/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-sysmgmt-health
-version: 1.2.13
+version: 1.2.14
 description: An extension of the official prometheus-operator helm chart for monitoring
 keywords:
 - sysmgmt-health

--- a/kubernetes/cray-sysmgmt-health/values.yaml
+++ b/kubernetes/cray-sysmgmt-health/values.yaml
@@ -252,7 +252,7 @@ victoria-metrics-k8s-stack:
         enabled: true
         image:
           repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
-          tag: 1.31.1
+          tag: 1.33.1
           pullPolicy: IfNotPresent
     cleanupCRD: true
     createCRD: false
@@ -526,8 +526,6 @@ victoria-metrics-k8s-stack:
         header_name: X-WEBAUTH-USER
         header_property: username
         auto_sign_up: true
-      plugins:
-        allow_loading_unsigned_plugins: hpe-clusterview-panel
 
     sidecar:
       image:


### PR DESCRIPTION
## Summary and Scope

This PR is to upgrade the bitnami/kubectl image to the latest version 1.33.1

## Issues and Related PRs

* Resolves https://jira-pro.it.hpe.com:8443/browse/CASMMON-543
* Makes the changes missed in  https://jira-pro.it.hpe.com:8443/browse/CASMSMF-8515 

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * wasp

### Test description

- This image is used when the chart is uninstalled. It clears up all the vm crds in the namespace. So for testing we can check If the crds have been cleared when the chart gets uninstalled. 
- The cilium Hubble pod scrape remains because it was not created as a part of the cray-sysmgmt-health chart.

```
ncn-m001:/mnt/developer/akshar/543-CASMMON # helm uninstall -n sysmgmt-health cray-sysmgmt-health 
release "cray-sysmgmt-health" uninstalled

ncn-m001:/mnt/developer/akshar/543-CASMMON # echo $vm_crds 
vmagents.operator.victoriametrics.com vmalertmanagerconfigs.operator.victoriametrics.com vmalertmanagers.operator.victoriametrics.com vmalerts.operator.victoriametrics.com vmauths.operator.victoriametrics.com vmclusters.operator.victoriametrics.com vmnodescrapes.operator.victoriametrics.com vmpodscrapes.operator.victoriametrics.com vmprobes.operator.victoriametrics.com vmrules.operator.victoriametrics.com vmscrapeconfigs.operator.victoriametrics.com vmservicescrapes.operator.victoriametrics.com vmsingles.operator.victoriametrics.com vmstaticscrapes.operator.victoriametrics.com vmusers.operator.victoriametrics.com

ncn-m001:/mnt/developer/akshar/543-CASMMON # for vm_crd in ${vm_crds[@]}; do
> kubectl get $vm_crd -n sysmgmt-health
> done
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
NAME            AGE   STATUS        SYNC ERROR
cilium-hubble   29d   operational   
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.
No resources found in sysmgmt-health namespace.

```
- Screenshot of a dashboard that uses the signed hpehpc-grafanaclusterview-panel version 1.3.2

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d3de7964-637a-455a-8af9-1c232fb0c4d8" />


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

